### PR TITLE
Remove addTotalBreakdown (deprecated function)

### DIFF
--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -627,38 +627,3 @@ def test_waterfall_not_implemented(sample_data):
         waterfall(df, **kwargs)
     assert str(exc_info.value) == 'We will add support for upperGroup only ' \
                                   'on you request, please contact the devs'
-
-
-def test_add_total_breakdown(sample_data):
-    """ It should add a breakdown category """
-    df = pd.DataFrame([
-        {'gender': 'male', 'sport': 'bicycle', 'number': 17},
-        {'gender': 'female', 'sport': 'basketball', 'number': 17},
-        {'gender': 'male', 'sport': 'basketball', 'number': 3},
-        {'gender': 'female', 'sport': 'football', 'number': 7},
-        {'gender': 'female', 'sport': 'running', 'number': 30},
-        {'gender': 'male', 'sport': 'running', 'number': 20},
-        {'gender': 'male', 'sport': 'football', 'number': 21},
-        {'gender': 'female', 'sport': 'bicycle', 'number': 17}
-    ])
-
-    expected = pd.DataFrame([
-        {'breakdown': 'total', 'gender': nan, 'number': 50, 'sport': 'running'},
-        {'breakdown': 'total', 'gender': nan, 'number': 34, 'sport': 'bicycle'},
-        {'breakdown': nan, 'gender': 'female', 'number': 30, 'sport': 'running'},
-        {'breakdown': 'total', 'gender': nan, 'number': 28, 'sport': 'football'},
-        {'breakdown': nan, 'gender': 'male', 'number': 21, 'sport': 'football'},
-        {'breakdown': nan, 'gender': 'male', 'number': 20, 'sport': 'running'},
-        {'breakdown': 'total', 'gender': nan, 'number': 20, 'sport': 'basketball'},
-        {'breakdown': nan, 'gender': 'male', 'number': 17, 'sport': 'bicycle'},
-        {'breakdown': nan, 'gender': 'female', 'number': 17, 'sport': 'basketball'},
-        {'breakdown': nan, 'gender': 'female', 'number': 17, 'sport': 'bicycle'},
-        {'breakdown': nan, 'gender': 'female', 'number': 7, 'sport': 'football'},
-        {'breakdown': nan, 'gender': 'male', 'number': 3, 'sport': 'basketball'}
-    ])
-
-    res = add_total_breakdown(df, ['sport'], 'breakdown', 'total',
-                              limitResults={'sortBy': {'value': 'number'},
-                                            'ids': ['sport'],
-                                            'limitTo': 5})
-    assert res.reset_index(drop=True).equals(expected)

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -8,8 +8,7 @@ from toucan_data_sdk.utils.postprocess import (
     replace, rename, melt, top, pivot,
     pivot_by_group, argmax, fillna,
     query_df, add, subtract, multiply,
-    divide, cumsum, percentage, waterfall,
-    add_total_breakdown
+    divide, cumsum, percentage, waterfall
 )
 
 

--- a/toucan_data_sdk/utils/__init__.py
+++ b/toucan_data_sdk/utils/__init__.py
@@ -16,7 +16,7 @@ from .postprocess import (
     melt, top, pivot, pivot_by_group,
     argmax, fillna, query_df,
     add, subtract, multiply, divide, cumsum,
-    percentage, waterfall, add_total_breakdown
+    percentage, waterfall
 )
 from .roll_up import roll_up
 from .two_values_melt import two_values_melt

--- a/toucan_data_sdk/utils/postprocess.py
+++ b/toucan_data_sdk/utils/postprocess.py
@@ -475,47 +475,4 @@ def waterfall(df, date, value, start, end, upperGroup,  # noqa:C901
 
     return ret
 
-
-def add_total_breakdown(df, ids, breakdown, label, limitResults=None):
-    """
-    Adds a Total breakdown category depending on the parameters
-    Args:
-        df (pd.DataFrame): DataFrame to transform
-        ids (list): names of the columns to group by
-        breakdown (str): name of the breakdown column
-        label (str): name to give to the Total breakdown
-        limitResults (dict): Optional, limit the number of result for each group
-            - sortBy (dict): Optional, use this if values need to be sorted before limiting
-                - value (str): the name of the column to sort by
-                - desc (bool): Default True, sort direction
-            - limitTo (str): Number of result to limit
-            - ids (list): Names of the columns to group by. Each group will
-            will be limited to 'limitTo' results
-    Returns:
-        pd.DataFrame: array with total values added
-    """
-    total_df = df.groupby(ids, as_index=False).sum()
-    total_df[breakdown] = label
-    df = pd.concat([df, total_df])
-
-    if limitResults is not None:
-        if 'sortBy' in limitResults:
-            try:
-                ascending = not limitResults['sortBy']['desc']
-            except KeyError:
-                ascending = False
-            df.sort_values(
-                limitResults['sortBy']['value'],
-                ascending=ascending,
-                inplace=True
-            )
-        df = df.groupby(
-            limitResults['ids'], as_index=False
-        ).head(limitResults['limitTo'])
-
-    return df
-
-
-# DO NOT REMOVE as long as these names are used in some front configs
-addTotalBreakdown = add_total_breakdown
 query = query_df


### PR DESCRIPTION
Remove addTotalBreakdown and add_total_breakdown from postprocess function

Not use since `reset: all` exists for filters.