### PR TITLE
hotfix :: function name and wording

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = toucan_data_sdk
 description = Toucan data SDK
 author = Toucan Toco
 url = https://github.com/ToucanToco/toucan-data-sdk
-version = 2.0.0
+version = 2.1.0
 license = BSD
 classifiers=
     Intended Audience :: Developers

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = toucan_data_sdk
 description = Toucan data SDK
 author = Toucan Toco
 url = https://github.com/ToucanToco/toucan-data-sdk
-version = 2.1.0
+version = 2.0.1
 license = BSD
 classifiers=
     Intended Audience :: Developers

--- a/tests/utils/generic/test_add_missing_row.py
+++ b/tests/utils/generic/test_add_missing_row.py
@@ -108,7 +108,7 @@ def test_add_missing_row_between_and_before():
     assert result == expected
 
 
-def test_add_missing_row_keep_cols():
+def test_add_missing_row_cols_to_keep():
     """
     It should add missing row compare to a reference column and keep an other column
     """
@@ -119,7 +119,7 @@ def test_add_missing_row_keep_cols():
         input_df,
         id_cols=['group'],
         reference_col='date',
-        keep_cols=['month']
+        cols_to_keep=['month']
     )
     mask = (new_df['group'] == 'B') & (new_df['date'] == 20161001)
     assert len(new_df.loc[mask, 'month']) == 1

--- a/tests/utils/generic/test_combine_columns_aggregation.py
+++ b/tests/utils/generic/test_combine_columns_aggregation.py
@@ -1,8 +1,8 @@
 import pandas as pd
-from toucan_data_sdk.utils.generic import multiple_aggregations
+from toucan_data_sdk.utils.generic import combine_columns_aggregation
 
 
-def test_aggregate_requesters():
+def test_combine_columns_aggregation():
     """
     It should aggregate for requesters without losing NaN values
     """
@@ -12,7 +12,7 @@ def test_aggregate_requesters():
         {'year': 2017, 'filter1': 'B', 'filter2': pd.np.nan, 'value': 2},
         {'year': 2017, 'filter1': 'B', 'filter2': 'C', 'value': 8},
     ])
-    res = multiple_aggregations(
+    res = combine_columns_aggregation(
         df,
         ['year'],
         {'filter1': 'All 1', 'filter2': 'All 2'},
@@ -22,7 +22,7 @@ def test_aggregate_requesters():
     mask = (res['filter1'] == 'All 1') & (res['filter2'] == 'C')
     assert res[mask]['value'][0] == 9
 
-    res = multiple_aggregations(
+    res = combine_columns_aggregation(
         df,
         ['year'],
         {'filter1': 'All 1', 'filter2': 'All 2'},

--- a/toucan_data_sdk/utils/generic/__init__.py
+++ b/toucan_data_sdk/utils/generic/__init__.py
@@ -2,7 +2,7 @@
 # https://drive.google.com/drive/folders/0B56th7Lb-9vScy0tMlpIeGNxQ0E
 
 from .add_missing_row import add_missing_row
-from .multiple_aggregations import multiple_aggregations
+from .combine_columns_aggregation import combine_columns_aggregation
 from .clean import clean_dataframe
 from .compute_cumsum import compute_cumsum
 from .compute_evolution import (

--- a/toucan_data_sdk/utils/generic/add_missing_row.py
+++ b/toucan_data_sdk/utils/generic/add_missing_row.py
@@ -6,7 +6,8 @@ from toucan_data_sdk.utils.helpers import (
 )
 
 
-def add_missing_row(df, id_cols, reference_col, complete_index=None, method=None, cols_to_keep=None):
+def add_missing_row(df, id_cols, reference_col, complete_index=None, method=None,
+                    cols_to_keep=None):
     """
     Add missing row to a df base on a reference column
     - `id_cols` are the columns id to group,

--- a/toucan_data_sdk/utils/generic/add_missing_row.py
+++ b/toucan_data_sdk/utils/generic/add_missing_row.py
@@ -6,7 +6,7 @@ from toucan_data_sdk.utils.helpers import (
 )
 
 
-def add_missing_row(df, id_cols, reference_col, complete_index=None, method=None, keep_cols=None):
+def add_missing_row(df, id_cols, reference_col, complete_index=None, method=None, cols_to_keep=None):
     """
     Add missing row to a df base on a reference column
     - `id_cols` are the columns id to group,
@@ -15,7 +15,7 @@ def add_missing_row(df, id_cols, reference_col, complete_index=None, method=None
        by default use the function `unique` on reference_col. Can be dict for date_range
     - `method` (optional) method to choose values to keep.
        E.g between min and max value of the group.
-    - `keep_cols` (optional) is the columns link to the reference_col to keep.
+    - `cols_to_keep` (optional) is the columns link to the reference_col to keep.
 
     For example :
 
@@ -48,10 +48,10 @@ def add_missing_row(df, id_cols, reference_col, complete_index=None, method=None
         method (str):
         keep_cols (list(str)):
     """
-    if keep_cols is None:
+    if cols_to_keep is None:
         cols_for_index = [reference_col]
     else:
-        cols_for_index = [reference_col] + keep_cols
+        cols_for_index = [reference_col] + cols_to_keep
     check_params_columns_duplicate(id_cols + cols_for_index)
 
     if method == 'between' or method == 'between_and_after':

--- a/toucan_data_sdk/utils/generic/combine_columns_aggregation.py
+++ b/toucan_data_sdk/utils/generic/combine_columns_aggregation.py
@@ -2,29 +2,29 @@ import pandas as pd
 import itertools
 
 
-def multiple_aggregations(
+def combine_columns_aggregation(
     df,
     id_cols,
-    requesters,
+    cols_for_combination,
     agg_func='sum'
 ):
     """
     Aggregates data to reproduce "All" category for requester
     - `id_cols` are the columns id to group,
-    - `requesters` is a dict with the colums corresponding to
+    - `cols_for_combination` is a dict with the colums corresponding to
        the filters as key and their default value as value
     - `agg_func` (optional) is the function to use for aggregating the data.
        Can be callable, string, dictionary, or list of string/callables (by default 'sum')
     """
-    requesters_cols = list(requesters.keys())
+    requesters_cols = list(cols_for_combination.keys())
     requester_combination = [
         list(item) for i in range(0, len(requesters_cols) + 1)
         for item in itertools.combinations(requesters_cols, i)]
     dfs_result = []
     for comb in requester_combination:
         df_tmp = df.groupby(id_cols + comb).agg(agg_func).reset_index()
-        for key in (set(requesters.keys()) - set(comb)):
-            df_tmp[key] = requesters[key]
+        for key in (set(cols_for_combination.keys()) - set(comb)):
+            df_tmp[key] = cols_for_combination[key]
         dfs_result.append(df_tmp)
 
     return pd.concat(dfs_result)

--- a/toucan_data_sdk/utils/generic/compute_cumsum.py
+++ b/toucan_data_sdk/utils/generic/compute_cumsum.py
@@ -19,6 +19,7 @@ def compute_cumsum(
     - `id_cols` are the columns id to create each group,
     - `reference_cols` are the columns to order the cumsum,
     - `value_cols` are the columns to cumsum,
+    - `new_value_cols`are the new columns with the result cumsum
     - `cols_to_keep` are other column to keep in the dataframe. This option can
      be used if there is only one row by group [id_cols + reference_cols]
 


### PR DESCRIPTION
Fix wording
- function name `aggregate_requesters` to `combine_columns_aggregation`
- parameters of add_missing_row