### PR TITLE
Add rank util with test and new init

### DIFF
--- a/tests/utils/postprocess/test_rank.py
+++ b/tests/utils/postprocess/test_rank.py
@@ -1,0 +1,52 @@
+import pandas as pd
+import pytest
+
+from toucan_data_sdk.utils.postprocess import rank
+
+data = pd.DataFrame([{'ENTITY': 'A', 'YEAR': '2017', 'VALUE_1': 10, 'VALUE_2': 3},
+                     {'ENTITY': 'A', 'YEAR': '2017', 'VALUE_1': 20, 'VALUE_2': 1},
+                     {'ENTITY': 'A', 'YEAR': '2018', 'VALUE_1': 10, 'VALUE_2': 5},
+                     {'ENTITY': 'A', 'YEAR': '2018', 'VALUE_1': 30, 'VALUE_2': 4},
+                     {'ENTITY': 'B', 'YEAR': '2017', 'VALUE_1': 60, 'VALUE_2': 4},
+                     {'ENTITY': 'B', 'YEAR': '2017', 'VALUE_1': 40, 'VALUE_2': 3},
+                     {'ENTITY': 'B', 'YEAR': '2018', 'VALUE_1': 50, 'VALUE_2': 7},
+                     {'ENTITY': 'B', 'YEAR': '2018', 'VALUE_1': 60, 'VALUE_2': 6}
+                    ])
+
+def test_invalid_value_col_type():
+
+    with pytest.raises(TypeError):
+        rank(data, value_cols='ENTITY')
+
+def test_empty_rank_cols_names():
+
+    df = rank(data, value_cols='VALUE_1')
+    assert df.columns[-1] == 'VALUE_1_rank'
+
+def test_empty_group_cols():
+
+    df = rank(data, value_cols=['VALUE_1', 'VALUE_2'])
+    expected = pd.DataFrame([{'VALUE_1_rank': 1, 'VALUE_2_rank': 2},
+                             {'VALUE_1_rank': 3, 'VALUE_2_rank': 1},
+                             {'VALUE_1_rank': 1, 'VALUE_2_rank': 6},
+                             {'VALUE_1_rank': 4, 'VALUE_2_rank': 4},
+                             {'VALUE_1_rank': 7, 'VALUE_2_rank': 4},
+                             {'VALUE_1_rank': 5, 'VALUE_2_rank': 2},
+                             {'VALUE_1_rank': 6, 'VALUE_2_rank': 8},
+                             {'VALUE_1_rank': 7, 'VALUE_2_rank': 7}
+                            ])
+    assert (df[['VALUE_1_rank', 'VALUE_2_rank']] == expected).all().all()
+
+def test_group_cols():
+
+    df = rank(data, value_cols=['VALUE_1', 'VALUE_2'], group_cols='YEAR')
+    expected = pd.DataFrame([{'VALUE_1_rank': 1, 'VALUE_2_rank': 2},
+                             {'VALUE_1_rank': 2, 'VALUE_2_rank': 1},
+                             {'VALUE_1_rank': 1, 'VALUE_2_rank': 2},
+                             {'VALUE_1_rank': 2, 'VALUE_2_rank': 1},
+                             {'VALUE_1_rank': 4, 'VALUE_2_rank': 4},
+                             {'VALUE_1_rank': 3, 'VALUE_2_rank': 2},
+                             {'VALUE_1_rank': 3, 'VALUE_2_rank': 4},
+                             {'VALUE_1_rank': 4, 'VALUE_2_rank': 3}
+                            ])
+    assert (df[['VALUE_1_rank', 'VALUE_2_rank']] == expected).all().all()

--- a/tests/utils/postprocess/test_rank.py
+++ b/tests/utils/postprocess/test_rank.py
@@ -11,20 +11,20 @@ data = pd.DataFrame([{'ENTITY': 'A', 'YEAR': '2017', 'VALUE_1': 10, 'VALUE_2': 3
                      {'ENTITY': 'B', 'YEAR': '2017', 'VALUE_1': 40, 'VALUE_2': 3},
                      {'ENTITY': 'B', 'YEAR': '2018', 'VALUE_1': 50, 'VALUE_2': 7},
                      {'ENTITY': 'B', 'YEAR': '2018', 'VALUE_1': 60, 'VALUE_2': 6}
-                    ])
+                     ])
+
 
 def test_invalid_value_col_type():
-
     with pytest.raises(TypeError):
         rank(data, value_cols='ENTITY')
 
-def test_empty_rank_cols_names():
 
+def test_empty_rank_cols_names():
     df = rank(data, value_cols='VALUE_1')
     assert df.columns[-1] == 'VALUE_1_rank'
 
-def test_empty_group_cols():
 
+def test_empty_group_cols():
     df = rank(data, value_cols=['VALUE_1', 'VALUE_2'])
     expected = pd.DataFrame([{'VALUE_1_rank': 1, 'VALUE_2_rank': 2},
                              {'VALUE_1_rank': 3, 'VALUE_2_rank': 1},
@@ -34,19 +34,19 @@ def test_empty_group_cols():
                              {'VALUE_1_rank': 5, 'VALUE_2_rank': 2},
                              {'VALUE_1_rank': 6, 'VALUE_2_rank': 8},
                              {'VALUE_1_rank': 7, 'VALUE_2_rank': 7}
-                            ])
-    assert (df[['VALUE_1_rank', 'VALUE_2_rank']] == expected).all().all()
+                             ])
+    assert df[['VALUE_1_rank', 'VALUE_2_rank']].equals(expected)
+
 
 def test_group_cols():
-
-    df = rank(data, value_cols=['VALUE_1', 'VALUE_2'], group_cols='YEAR')
-    expected = pd.DataFrame([{'VALUE_1_rank': 1, 'VALUE_2_rank': 2},
-                             {'VALUE_1_rank': 2, 'VALUE_2_rank': 1},
-                             {'VALUE_1_rank': 1, 'VALUE_2_rank': 2},
-                             {'VALUE_1_rank': 2, 'VALUE_2_rank': 1},
-                             {'VALUE_1_rank': 4, 'VALUE_2_rank': 4},
-                             {'VALUE_1_rank': 3, 'VALUE_2_rank': 2},
-                             {'VALUE_1_rank': 3, 'VALUE_2_rank': 4},
-                             {'VALUE_1_rank': 4, 'VALUE_2_rank': 3}
-                            ])
-    assert (df[['VALUE_1_rank', 'VALUE_2_rank']] == expected).all().all()
+    df = rank(data, value_cols=['VALUE_1', 'VALUE_2'], group_cols='YEAR', method='average')
+    expected = pd.DataFrame([{'VALUE_1_rank': 1.0, 'VALUE_2_rank': 2.5},
+                             {'VALUE_1_rank': 2.0, 'VALUE_2_rank': 1.0},
+                             {'VALUE_1_rank': 1.0, 'VALUE_2_rank': 2.0},
+                             {'VALUE_1_rank': 2.0, 'VALUE_2_rank': 1.0},
+                             {'VALUE_1_rank': 4.0, 'VALUE_2_rank': 4.0},
+                             {'VALUE_1_rank': 3.0, 'VALUE_2_rank': 2.5},
+                             {'VALUE_1_rank': 3.0, 'VALUE_2_rank': 4.0},
+                             {'VALUE_1_rank': 4.0, 'VALUE_2_rank': 3.0}
+                             ])
+    assert df[['VALUE_1_rank', 'VALUE_2_rank']].equals(expected)

--- a/toucan_data_sdk/utils/postprocess/__init__.py
+++ b/toucan_data_sdk/utils/postprocess/__init__.py
@@ -7,6 +7,7 @@ from .melt import melt
 from .percentage import percentage
 from .pivot import pivot, pivot_by_group
 from .query_df import query, query_df
+from .rank import rank
 from .rename import rename
 from .replace import replace
 from .sort import sort_values

--- a/toucan_data_sdk/utils/postprocess/rank.py
+++ b/toucan_data_sdk/utils/postprocess/rank.py
@@ -17,8 +17,8 @@ def rank(df, value_cols, group_cols=None, rank_cols_names=None, method='min', as
         - 'average': average rank of group
         - 'first': ranks assigned in order the values appear in the series
         - 'dense': like 'min', but rank always increases by 1 between groups
-    :param ascending (bool, optional): True (default) or False whether the rank should be determined based on ascending or
-      descending order respectively
+    :param ascending (bool, optional): True (default) or False whether the rank should be determined based 
+      on ascending or descending order respectively
     :return: the df dataframe with the new ranking columns.
 
 

--- a/toucan_data_sdk/utils/postprocess/rank.py
+++ b/toucan_data_sdk/utils/postprocess/rank.py
@@ -1,23 +1,24 @@
 import numpy as np
 
+
 def rank(df, value_cols, group_cols=None, rank_cols_names=None, method='min', ascending=True):
     """
     This function creates rank columns based on numeric values to be ranked.
 
     :param df: the dataframe to which ranking column(s) will be added
     :param value_cols (str or list(str)): name(s) of the columns used
-    :param group_cols (str or list(str), optionnal): name(s) of the column(s) used to create each group inside
-    which independent ranking needs to be applied
-    :param rank_cols_names (str or list(str), optionnal): the names of the added ranking columns. If not filled, the
-    ranking will be named after the value_cols with a '_rank' suffix
+    :param group_cols (str or list(str), optionnal): name(s) of the column(s) used to
+      create each group inside which independent ranking needs to be applied
+    :param rank_cols_names (str or list(str), optionnal): the names of the added ranking columns.
+      If not filled, the ranking will be named after the value_cols with a '_rank' suffix
     :param method (str, optional): method to use when encountering equal values:
         - 'min' (default): lowest rank in group
         - 'max': highest rank in group
         - 'average': average rank of group
-        - 'fisrt': ranks assigned in order the values appear in the series
+        - 'first': ranks assigned in order the values appear in the series
         - 'dense': like 'min', but rank always increases by 1 between groups
     :param ascending (bool, optional): True (default) or False whether the rank should be determined based on ascending or
-    descending order respectively
+      descending order respectively
     :return: the df dataframe with the new ranking columns.
 
 
@@ -50,16 +51,17 @@ def rank(df, value_cols, group_cols=None, rank_cols_names=None, method='min', as
     2. rank(df, value_cols='VALUE_1', group_cols='YEAR', method='average') returns:
 
     ENTITY  YEAR  VALUE_1  VALUE_2  RANK_1
-       A    2017    10       3        1
-       A    2017    20       1        2
-       A    2018    10       5        1
-       A    2018    30       4        2
-       B    2017    60       4        4
-       B    2017    40       3        3
-       B    2018    50       6       3.5
-       B    2018    50       7       3.5
+       A    2017    10       3.0     1.0
+       A    2017    20       1.0     2.0
+       A    2018    10       5.0     1.0
+       A    2018    30       4.0     2.0
+       B    2017    60       4.0     4.0
+       B    2017    40       3.0     3.0
+       B    2018    50       6.0     3.5
+       B    2018    50       7.0     3.5
 
-    3. rank(df, value_cols=['VALUE_1', 'VALUE_2'], group_cols=['ENTITY', 'YEAR'], rank_cols_name=['RANK_1', 'RANK_2'])
+    3. rank(df, value_cols=['VALUE_1', 'VALUE_2'], group_cols=['ENTITY', 'YEAR'],
+            rank_cols_name=['RANK_1', 'RANK_2']):
     returns:
 
     ENTITY  YEAR  VALUE_1  VALUE_2  RANK_1  RANK_2
@@ -74,7 +76,7 @@ def rank(df, value_cols, group_cols=None, rank_cols_names=None, method='min', as
 
     """
 
-    value_cols = [value_cols] if type(value_cols) != list else value_cols
+    value_cols = [value_cols] if not isinstance(value_cols, list) else value_cols
     for col in value_cols:
         if not np.issubdtype(df[col].dtype, np.number):
             raise TypeError(col + " specified in value_cols must be of numeric type")
@@ -85,8 +87,11 @@ def rank(df, value_cols, group_cols=None, rank_cols_names=None, method='min', as
     if group_cols is None:
         df[rank_cols_names] = df[value_cols].rank(method=method, ascending=ascending)
     else:
-        df[rank_cols_names] = df.groupby(group_cols,
-                                         as_index=False)[value_cols].rank(method=method,
-                                                                          ascending=ascending).reset_index(drop=True)
+        df[rank_cols_names] = (df.groupby(group_cols, as_index=False)[value_cols]
+                                 .rank(method=method, ascending=ascending)
+                                 .reset_index(drop=True))
+
+    if method != 'average':
+        df[rank_cols_names] = df[rank_cols_names].astype('int')
 
     return df

--- a/toucan_data_sdk/utils/postprocess/rank.py
+++ b/toucan_data_sdk/utils/postprocess/rank.py
@@ -1,0 +1,92 @@
+import numpy as np
+
+def rank(df, value_cols, group_cols=None, rank_cols_names=None, method='min', ascending=True):
+    """
+    This function creates rank columns based on numeric values to be ranked.
+
+    :param df: the dataframe to which ranking column(s) will be added
+    :param value_cols (str or list(str)): name(s) of the columns used
+    :param group_cols (str or list(str), optionnal): name(s) of the column(s) used to create each group inside
+    which independent ranking needs to be applied
+    :param rank_cols_names (str or list(str), optionnal): the names of the added ranking columns. If not filled, the
+    ranking will be named after the value_cols with a '_rank' suffix
+    :param method (str, optional): method to use when encountering equal values:
+        - 'min' (default): lowest rank in group
+        - 'max': highest rank in group
+        - 'average': average rank of group
+        - 'fisrt': ranks assigned in order the values appear in the series
+        - 'dense': like 'min', but rank always increases by 1 between groups
+    :param ascending (bool, optional): True (default) or False whether the rank should be determined based on ascending or
+    descending order respectively
+    :return: the df dataframe with the new ranking columns.
+
+
+    Examples:
+
+    Dataset df:
+
+    ENTITY  YEAR  VALUE_1  VALUE_2
+       A    2017    10       3
+       A    2017    20       1
+       A    2018    10       5
+       A    2018    30       4
+       B    2017    60       4
+       B    2017    40       3
+       B    2018    50       7
+       B    2018    60       6
+
+    1. rank(df, value_cols='VALUE_1') returns:
+
+    ENTITY  YEAR  VALUE_1  VALUE_2  VALUE_1_rank
+       A    2017    10       3           1
+       A    2017    20       1           3
+       A    2018    10       5           1
+       A    2018    30       4           4
+       B    2017    60       4           7
+       B    2017    40       3           5
+       B    2018    50       6           6
+       B    2018    50       7           6
+
+    2. rank(df, value_cols='VALUE_1', group_cols='YEAR', method='average') returns:
+
+    ENTITY  YEAR  VALUE_1  VALUE_2  RANK_1
+       A    2017    10       3        1
+       A    2017    20       1        2
+       A    2018    10       5        1
+       A    2018    30       4        2
+       B    2017    60       4        4
+       B    2017    40       3        3
+       B    2018    50       6       3.5
+       B    2018    50       7       3.5
+
+    3. rank(df, value_cols=['VALUE_1', 'VALUE_2'], group_cols=['ENTITY', 'YEAR'], rank_cols_name=['RANK_1', 'RANK_2'])
+    returns:
+
+    ENTITY  YEAR  VALUE_1  VALUE_2  RANK_1  RANK_2
+       A    2017    10       3        1       2
+       A    2017    20       1        2       1
+       A    2018    10       5        1       2
+       A    2018    30       4        2       1
+       B    2017    60       4        2       2
+       B    2017    40       3        1       1
+       B    2018    50       6        1       1
+       B    2018    50       7        1       2
+
+    """
+
+    value_cols = [value_cols] if type(value_cols) != list else value_cols
+    for col in value_cols:
+        if not np.issubdtype(df[col].dtype, np.number):
+            raise TypeError(col + " specified in value_cols must be of numeric type")
+
+    if rank_cols_names is None:
+        rank_cols_names = [x + '_rank' for x in value_cols]
+
+    if group_cols is None:
+        df[rank_cols_names] = df[value_cols].rank(method=method, ascending=ascending)
+    else:
+        df[rank_cols_names] = df.groupby(group_cols,
+                                         as_index=False)[value_cols].rank(method=method,
+                                                                          ascending=ascending).reset_index(drop=True)
+
+    return df

--- a/toucan_data_sdk/utils/postprocess/rank.py
+++ b/toucan_data_sdk/utils/postprocess/rank.py
@@ -61,8 +61,7 @@ def rank(df, value_cols, group_cols=None, rank_cols_names=None, method='min', as
        B    2018    50       7.0     3.5
 
     3. rank(df, value_cols=['VALUE_1', 'VALUE_2'], group_cols=['ENTITY', 'YEAR'],
-            rank_cols_name=['RANK_1', 'RANK_2']):
-    returns:
+            rank_cols_name=['RANK_1', 'RANK_2']) returns:
 
     ENTITY  YEAR  VALUE_1  VALUE_2  RANK_1  RANK_2
        A    2017    10       3        1       2


### PR DESCRIPTION
Util rank:    

    def rank(df, value_cols, group_cols=None, rank_cols_names=None, method='min', ascending=True):

    This function creates rank columns based on numeric values to be ranked.

    :param df: the dataframe to which ranking column(s) will be added
    :param value_cols (str or list(str)): name(s) of the columns used
    :param group_cols (str or list(str), optionnal): name(s) of the column(s) used to create each group inside
    which independent ranking needs to be applied
    :param rank_cols_names (str or list(str), optionnal): the names of the added ranking columns. If not filled, the
    ranking will be named after the value_cols with a '_rank' suffix
    :param method (str, optional): method to use when encountering equal values:
        - 'min' (default): lowest rank in group
        - 'max': highest rank in group
        - 'average': average rank of group
        - 'fisrt': ranks assigned in order the values appear in the series
        - 'dense': like 'min', but rank always increases by 1 between groups
    :param ascending (bool, optional): True (default) or False whether the rank should be determined based on ascending or
    descending order respectively
    :return: the df dataframe with the new ranking columns.


    Examples:

    Dataset df:

    ENTITY  YEAR  VALUE_1  VALUE_2
       A    2017    10       3
       A    2017    20       1
       A    2018    10       5
       A    2018    30       4
       B    2017    60       4
       B    2017    40       3
       B    2018    50       7
       B    2018    60       6

    1. rank(df, value_cols='VALUE_1') returns:

    ENTITY  YEAR  VALUE_1  VALUE_2  VALUE_1_rank
       A    2017    10       3           1
       A    2017    20       1           3
       A    2018    10       5           1
       A    2018    30       4           4
       B    2017    60       4           7
       B    2017    40       3           5
       B    2018    50       6           6
       B    2018    50       7           6

    2. rank(df, value_cols='VALUE_1', group_cols='YEAR', method='average') returns:

    ENTITY  YEAR  VALUE_1  VALUE_2  RANK_1
       A    2017    10       3        1
       A    2017    20       1        2
       A    2018    10       5        1
       A    2018    30       4        2
       B    2017    60       4        4
       B    2017    40       3        3
       B    2018    50       6       3.5
       B    2018    50       7       3.5

    3. rank(df, value_cols=['VALUE_1', 'VALUE_2'], group_cols=['ENTITY', 'YEAR'], rank_cols_name=['RANK_1', 'RANK_2'])
    returns:

    ENTITY  YEAR  VALUE_1  VALUE_2  RANK_1  RANK_2
       A    2017    10       3        1       2
       A    2017    20       1        2       1
       A    2018    10       5        1       2
       A    2018    30       4        2       1
       B    2017    60       4        2       2
       B    2017    40       3        1       1
       B    2018    50       6        1       1
       B    2018    50       7        1       2

 