### PR TITLE
f/add new utc param toucan is going international

### DIFF
--- a/tests/utils/postprocess/test_converter.py
+++ b/tests/utils/postprocess/test_converter.py
@@ -57,14 +57,14 @@ def test_change_date_format():
 
     expected_result = ['01/01/2016', '06/01/2016', '01/05/2017']
 
-    # without format
+    # without input_format
     config = {
         'column': 'date',
         'output_format': '%d/%m/%Y'}
     new_df = change_date_format(df.copy(), **config)
     assert list(new_df.date) == expected_result
 
-    # without new_column
+    # without new_column and input_format
     config = {
         'column': 'date',
         'input_format': '%Y%m%d',
@@ -72,7 +72,7 @@ def test_change_date_format():
     new_df = change_date_format(df.copy(), **config)
     assert list(new_df.date) == expected_result
 
-    # with new_column
+    # with input_format
     config = {
         'column': 'date',
         'input_format': '%Y%m%d',
@@ -80,6 +80,17 @@ def test_change_date_format():
         'new_column': 'new_date'}
     new_df = change_date_format(df.copy(), **config)
     assert list(new_df.new_date) == expected_result
+
+    #with utc (eh ouaaaais international mon pote)
+    df = pd.DataFrame([
+        {'date': "2018-11-13 08:00:02.091000+00:00", 'city': "Rennes"},
+        {'date': "2018-11-13 12:01:05.091000+00:00", 'city': "Nantes"},
+        {'date': "2018-11-13 10:12:09.091000+00:00", 'city': "Paris"},
+    ])
+    expected_result = ["09:00", "13:01", "11:12"]
+    config = {'column': 'date', 'output_format': '%H:%M', 'new_utc': "Europe/Paris"}
+    df_new = change_date_format(df.copy(), **config)
+    assert list(df_new.date) == expected_result
 
 
 def test_cast():

--- a/tests/utils/postprocess/test_converter.py
+++ b/tests/utils/postprocess/test_converter.py
@@ -81,7 +81,7 @@ def test_change_date_format():
     new_df = change_date_format(df.copy(), **config)
     assert list(new_df.new_date) == expected_result
 
-    #with utc (eh ouaaaais international mon pote)
+    # with utc (eh ouaaaais international mon pote)
     df = pd.DataFrame([
         {'date': "2018-11-13 08:00:02.091000+00:00", 'city': "Rennes"},
         {'date': "2018-11-13 12:01:05.091000+00:00", 'city': "Nantes"},

--- a/toucan_data_sdk/utils/postprocess/converter.py
+++ b/toucan_data_sdk/utils/postprocess/converter.py
@@ -26,8 +26,7 @@ def convert_datetime_to_str(df, *, column=None, format=None, new_column=None):
     df[new_column] = df[column].dt.strftime(format)
     return df
 
-
-def change_date_format(df, *, column, output_format, input_format=None, new_column=None):
+def change_date_format(df, *, column, output_format, input_format=None, new_column=None, new_utc=None):
     """
     Convert datetime column into string column
     :param df: Dataframe
@@ -35,12 +34,15 @@ def change_date_format(df, *, column, output_format, input_format=None, new_colu
     :param output_format: format of the output values
     :param input_format: format of the input values (If None, let the parser detect it)
     :param new_column: name of the output column
+    :param new_utc: (str) name of new utc
     :return: df
     """
     new_column = new_column or column
-    df[new_column] = pd.to_datetime(df[column], format=input_format).dt.strftime(output_format)
+    utc = new_utc or "UTC" # by default greenwitch utc
+    df[new_column] = (pd.to_datetime(df[column], format=input_format, utc=True)
+                      .dt.tz_convert(utc)
+                      .dt.strftime(output_format))
     return df
-
 
 def cast(df, column, type, new_column=None):
     """

--- a/toucan_data_sdk/utils/postprocess/converter.py
+++ b/toucan_data_sdk/utils/postprocess/converter.py
@@ -26,7 +26,9 @@ def convert_datetime_to_str(df, *, column=None, format=None, new_column=None):
     df[new_column] = df[column].dt.strftime(format)
     return df
 
-def change_date_format(df, *, column, output_format, input_format=None, new_column=None, new_utc=None):
+
+def change_date_format(df, *, column, output_format,
+                       input_format=None, new_column=None, new_utc=None):
     """
     Convert datetime column into string column
     :param df: Dataframe
@@ -38,11 +40,12 @@ def change_date_format(df, *, column, output_format, input_format=None, new_colu
     :return: df
     """
     new_column = new_column or column
-    utc = new_utc or "UTC" # by default greenwitch utc
+    utc = new_utc or "UTC"  # by default greenwitch utc
     df[new_column] = (pd.to_datetime(df[column], format=input_format, utc=True)
                       .dt.tz_convert(utc)
                       .dt.strftime(output_format))
     return df
+
 
 def cast(df, column, type, new_column=None):
     """


### PR DESCRIPTION
**Avant :**
La fonction `change_date_format` ne permet pas de changer d'UTC

**Maintenant :**
La fonction `change_date_format` permet de changer d'UTC en utilisant le param : `new_utc`
Le format de `new_utc` est ici : (pour la doc)

https://en.wikipedia.org/wiki/List_of_tz_database_time_zones