### PR TITLE
f/enhance date-requester-manager

### DIFF
--- a/tests/utils/generic/test_date_requester.py
+++ b/tests/utils/generic/test_date_requester.py
@@ -1,13 +1,33 @@
 from toucan_data_sdk.utils.generic import date_requester_generator
+import pandas as pd
 
 fixtures_base_dir = 'tests/fixtures'
+
+
+df = pd.DataFrame({
+    "date": ['2018-01-01', '2018-01-05', '2018-01-04', '2018-01-03', '2018-01-02'],
+    "my_kpi": [1, 2, 3, 4, 5]
+})
+
+
+df_2 = pd.DataFrame({
+    "date": ['01/01/2018', '05/01/2018', '04/01/2018', '03/01/2018', '02/01/2018'],
+    "my_kpi": [1, 2, 3, 4, 5]
+})
 
 
 def test_date_requester_generator():
 
     # mandatory only
-    result = date_requester_generator(start_date='2018-01-01',
-                                      end_date='2018-01-05',
+    result = date_requester_generator(df, "date",
+                                      frequency='D')
+    expected_date = ['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04', '2018-01-05']
+
+    assert result.shape == (5, 3)
+    assert list(result["DATE"]) == expected_date
+
+    # with a different date_column_format
+    result = date_requester_generator(df_2, "date", date_column_format="%d/%m/%Y",
                                       frequency='D')
     expected_date = ['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04', '2018-01-05']
 
@@ -15,8 +35,7 @@ def test_date_requester_generator():
     assert list(result["DATE"]) == expected_date
 
     # with format
-    result = date_requester_generator(start_date='2018-01-01',
-                                      end_date='2018-01-05',
+    result = date_requester_generator(df, "date",
                                       frequency='D',
                                       format="%d/%m/%Y")
     expected_date = ['01/01/2018', '02/01/2018', '03/01/2018', '04/01/2018', '05/01/2018']
@@ -27,8 +46,7 @@ def test_date_requester_generator():
     assert list(result["GRANULARITY"]) == expected_granularity
 
     # with multi-ganularity
-    result = date_requester_generator(start_date='2018-01-01',
-                                      end_date='2018-01-05',
+    result = date_requester_generator(df, "date",
                                       frequency='D',
                                       granularities={"day": "%d/%m/%Y", "Semaine": "%W"})
     expected_date = ['01/01/2018', '02/01/2018', '03/01/2018', '04/01/2018', '05/01/2018',
@@ -41,8 +59,7 @@ def test_date_requester_generator():
     assert list(result["GRANULARITY"]) == expected_granularity
 
     # with others_format
-    result = date_requester_generator(start_date='2018-01-01',
-                                      end_date='2018-01-05',
+    result = date_requester_generator(df, "date",
                                       frequency='D',
                                       granularities={"day": "%d/%m/%Y"},
                                       others_format={"year": "%Y"})
@@ -55,8 +72,7 @@ def test_date_requester_generator():
     assert list(result["year"]) == expected_year
 
     # with time delta
-    result = date_requester_generator(start_date='2018-01-01',
-                                      end_date='2018-01-05',
+    result = date_requester_generator(df, "date",
                                       frequency='D',
                                       times_delta={"Tomorow": "+1 day"})
 
@@ -66,8 +82,7 @@ def test_date_requester_generator():
     assert list(result["Tomorow"]) == expected_tomorow
 
     # with time delta and explicit format
-    result = date_requester_generator(start_date='2018-01-01',
-                                      end_date='2018-01-05',
+    result = date_requester_generator(df, "date",
                                       frequency='D',
                                       format="%d/%m",
                                       times_delta={"Tomorow": "+1 day"})

--- a/toucan_data_sdk/utils/generic/date_requester.py
+++ b/toucan_data_sdk/utils/generic/date_requester.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 
-def date_requester_generator(start_date, end_date, frequency,
+def date_requester_generator(df, date_column, frequency, date_column_format=None,
                              format='%Y-%m-%d', granularities=None,
                              others_format=None, times_delta=None):
     """
@@ -42,6 +42,9 @@ def date_requester_generator(start_date, end_date, frequency,
         - values (str): time delta
             Examples : '+1 day' '+3 day' '-4 month'
     """
+
+    start_date = pd.to_datetime(df[date_column], format=date_column_format).min()
+    end_date = pd.to_datetime(df[date_column], format=date_column_format).max()
 
     granularities = granularities or {'date': format}
     others_format = others_format or {}


### PR DESCRIPTION
*Avant :* 
la signature de la fonction `date_requester_generator` était : 
- start_date
- end_date
- frequency

*Maintenant :* 
la signature de la fonction `date_requester_generator` est : 
- df
- column_name
- frequency

--> start_date et end_date sont calculé à partir des valeurs de date présente dans la colonne `column_name` du DataFrame `df`

Avantage de ce changement : 
la fonction est utilisable dans le postprocess pour construire le date requester
 

⚠️ avant de merger cette PR il faut vérifier toutes les augment qui utilise cette fonction : 

- [ ] lien vers app qui utilise cette fonction
