### PR TITLE
Fix :: Amelioration de la function date requester generator

### DIFF
--- a/tests/utils/generic/test_date_requester.py
+++ b/tests/utils/generic/test_date_requester.py
@@ -1,5 +1,6 @@
-from toucan_data_sdk.utils.generic import date_requester_generator
 import pandas as pd
+
+from toucan_data_sdk.utils.generic import date_requester_generator
 
 fixtures_base_dir = 'tests/fixtures'
 

--- a/tests/utils/generic/test_date_requester.py
+++ b/tests/utils/generic/test_date_requester.py
@@ -1,13 +1,33 @@
 from toucan_data_sdk.utils.generic import date_requester_generator
+import pandas as pd
 
 fixtures_base_dir = 'tests/fixtures'
+
+
+df = pd.DataFrame({
+    "date": ['2018-01-01', '2018-01-05', '2018-01-04', '2018-01-03', '2018-01-02'],
+    "my_kpi": [1, 2, 3, 4, 5]
+})
+
+
+df_2 = pd.DataFrame({
+    "date": ['01/01/2018', '05/01/2018', '04/01/2018', '03/01/2018', '02/01/2018'],
+    "my_kpi": [1, 2, 3, 4, 5]
+})
 
 
 def test_date_requester_generator():
 
     # mandatory only
-    result = date_requester_generator(start_date='2018-01-01',
-                                      end_date='2018-01-05',
+    result = date_requester_generator(df, "date",
+                                      frequency='D')
+    expected_date = ['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04', '2018-01-05']
+
+    assert result.shape == (5, 3)
+    assert list(result["DATE"]) == expected_date
+
+    # with a different date_column_format
+    result = date_requester_generator(df_2, "date", date_column_format="%d/%m/%Y",
                                       frequency='D')
     expected_date = ['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04', '2018-01-05']
 
@@ -15,8 +35,7 @@ def test_date_requester_generator():
     assert list(result["DATE"]) == expected_date
 
     # with format
-    result = date_requester_generator(start_date='2018-01-01',
-                                      end_date='2018-01-05',
+    result = date_requester_generator(df, "date",
                                       frequency='D',
                                       format="%d/%m/%Y")
     expected_date = ['01/01/2018', '02/01/2018', '03/01/2018', '04/01/2018', '05/01/2018']
@@ -27,8 +46,7 @@ def test_date_requester_generator():
     assert list(result["GRANULARITY"]) == expected_granularity
 
     # with multi-ganularity
-    result = date_requester_generator(start_date='2018-01-01',
-                                      end_date='2018-01-05',
+    result = date_requester_generator(df, "date",
                                       frequency='D',
                                       granularities={"day": "%d/%m/%Y", "Semaine": "%W"})
     expected_date = ['01/01/2018', '02/01/2018', '03/01/2018', '04/01/2018', '05/01/2018',
@@ -41,8 +59,7 @@ def test_date_requester_generator():
     assert list(result["GRANULARITY"]) == expected_granularity
 
     # with others_format
-    result = date_requester_generator(start_date='2018-01-01',
-                                      end_date='2018-01-05',
+    result = date_requester_generator(df, "date",
                                       frequency='D',
                                       granularities={"day": "%d/%m/%Y"},
                                       others_format={"year": "%Y"})
@@ -55,8 +72,7 @@ def test_date_requester_generator():
     assert list(result["year"]) == expected_year
 
     # with time delta
-    result = date_requester_generator(start_date='2018-01-01',
-                                      end_date='2018-01-05',
+    result = date_requester_generator(df, "date",
                                       frequency='D',
                                       times_delta={"Tomorow": "+1 day"})
 
@@ -66,8 +82,7 @@ def test_date_requester_generator():
     assert list(result["Tomorow"]) == expected_tomorow
 
     # with time delta and explicit format
-    result = date_requester_generator(start_date='2018-01-01',
-                                      end_date='2018-01-05',
+    result = date_requester_generator(df, "date",
                                       frequency='D',
                                       format="%d/%m",
                                       times_delta={"Tomorow": "+1 day"})

--- a/toucan_data_sdk/utils/generic/date_requester.py
+++ b/toucan_data_sdk/utils/generic/date_requester.py
@@ -15,12 +15,13 @@ def date_requester_generator(df, date_column, frequency, date_column_format=None
 
     Mandatory :
     -----------
-    - start_date (str) : start date in %Y-%m%d format
-    - end_date (str): end date in %Y-%m%d format
+    - df (DataFrame) : dataframe from which  start and end date will be compute
+    - date_column (str): name of column containing date in df
     - frequency (str) : http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
 
     Optional :
     ----------
+    - date_column_format: format of the date in date_column
     - format: format of the date. !!! only use if granularity is None
         NB : same format in Toucan Toco
         Example : '%d/%m/%Y'

--- a/toucan_data_sdk/utils/generic/date_requester.py
+++ b/toucan_data_sdk/utils/generic/date_requester.py
@@ -2,15 +2,22 @@ import pandas as pd
 from typing import Dict
 
 
-def date_requester_generator(df, date_column: str, frequency: str, date_column_format: str = None,
-                             format: str = '%Y-%m-%d', granularities: Dict[str, str] = None,
-                             others_format: Dict[str, str] = None, times_delta: Dict[str, str] = None):
+def date_requester_generator(
+        df: pd.DataFrame,
+        date_column: str,
+        frequency: str,
+        date_column_format: str = None,
+        format: str = '%Y-%m-%d',
+        granularities: Dict[str, str] = None,
+        others_format: Dict[str, str] = None,
+        times_delta: Dict[str, str] = None
+) -> pd.DataFrame:
     """
-    **From a dataset containing dates in a column, return a dataset**
-    **with at least 3 columns :**
-    **- "DATE" : Label of date**
-    **- "DATETIME" : Date in datetime dtype**
-    **- "GRANULARITY" : Granualrity of date**
+    From a dataset containing dates in a column, return a dataset
+    with at least 3 columns :
+    - "DATE" : Label of date
+    - "DATETIME" : Date in datetime dtype
+    - "GRANULARITY" : Granualrity of date
 
     - `date_column` (str): name of column containing the date in the dataframe
     - `frequency` (str) : see [pandas doc](
@@ -32,7 +39,6 @@ def date_requester_generator(df, date_column: str, frequency: str, date_column_f
             NB : same format in Toucan Toco
             _Example : '%d/%m/%Y'_ (see [pandas doc](
             https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior))
-
     - `times_delta` (optional: dict) : Add new columns for each key
         - key (str) : name of the column
         - values (str): time delta

--- a/toucan_data_sdk/utils/generic/date_requester.py
+++ b/toucan_data_sdk/utils/generic/date_requester.py
@@ -15,34 +15,28 @@ def date_requester_generator(
     """
     From a dataset containing dates in a column, return a dataset
     with at least 3 columns :
-    - "DATE" : Label of date
-    - "DATETIME" : Date in datetime dtype
-    - "GRANULARITY" : Granualrity of date
-
-    - `date_column` (str): name of column containing the date in the dataframe
-    - `frequency` (str) : see [pandas doc](
+    * "DATE" : Label of date
+    * "DATETIME" : Date in datetime dtype
+    * "GRANULARITY" : Granularity of date
+    ---
+    * `date_column` (str): name of column containing the date in the dataframe
+    * `frequency` (str) : see [pandas doc](
     http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases)
-    - `date_column_format` (optional: str): format of the date in date_column
-    - `format` (optional: str): format of the date. !!! only use if granularity is None.
-        NB : same format in Toucan Toco
-        _Example : '%d/%m/%Y'_ (see [pandas doc](
+    * `date_column_format` (optional: str): format of the date in date_column
+    * `format` (optional: str): format of the date e.g. '%d/%m/%Y' (see [pandas doc](
         https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior))
-    - `granularities` (optional: dict):
-        - keys : name of the granularity
-        - values (str): Format of the granularity.
-            NB : same format in Toucan Toco
-            _Example : '%d/%m/%Y'_ (see [pandas doc](
+        WARNING: only use if `granularities` is None.
+    * `granularities` (optional: dict):
+        * keys : name of the granularity
+        * values (str): Format of the granularity e.g. '%d/%m/%Y' (see [pandas doc](
             https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior))
-    - `others_format` (optional: dict) : Add new columns for each key
-        - key (str) : name of the column
-        - values (str): format of the granularity.
-            NB : same format in Toucan Toco
-            _Example : '%d/%m/%Y'_ (see [pandas doc](
+    * `others_format` (optional: dict) : Add new columns for each key
+        * key (str) : name of the column
+        * values (str): format of the granularity e.g. '%d/%m/%Y' (see [pandas doc](
             https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior))
-    - `times_delta` (optional: dict) : Add new columns for each key
-        - key (str) : name of the column
-        - values (str): time delta
-            _Examples : '+1 day', '+3 day', '-4 month'_
+    * `times_delta` (optional: dict) : Add new columns for each key
+        * key (str) : name of the column
+        * values (str): time delta (e.g. '+1 day', '+3 day', '-4 month')
     """
 
     start_date = pd.to_datetime(df[date_column], format=date_column_format).min()

--- a/toucan_data_sdk/utils/generic/date_requester.py
+++ b/toucan_data_sdk/utils/generic/date_requester.py
@@ -1,11 +1,12 @@
 import pandas as pd
+from typing import Dict
 
 
-def date_requester_generator(df, date_column, frequency, date_column_format=None,
-                             format='%Y-%m-%d', granularities=None,
-                             others_format=None, times_delta=None):
+def date_requester_generator(df, date_column: str, frequency: str, date_column_format: str = None,
+                             format: str = '%Y-%m-%d', granularities: Dict[str, str] = None,
+                             others_format: Dict[str, str] = None, times_delta: Dict[str, str] = None):
     """
-    **From a dataframe containing dates in a column, return a dataframe**
+    **From a dataset containing dates in a column, return a dataset**
     **with at least 3 columns :**
     **- "DATE" : Label of date**
     **- "DATETIME" : Date in datetime dtype**

--- a/toucan_data_sdk/utils/generic/date_requester.py
+++ b/toucan_data_sdk/utils/generic/date_requester.py
@@ -15,28 +15,28 @@ def date_requester_generator(
     """
     From a dataset containing dates in a column, return a dataset
     with at least 3 columns :
-    * "DATE" : Label of date
-    * "DATETIME" : Date in datetime dtype
-    * "GRANULARITY" : Granularity of date
+    - "DATE" : Label of date
+    - "DATETIME" : Date in datetime dtype
+    - "GRANULARITY" : Granularity of date
     ---
-    * `date_column` (str): name of column containing the date in the dataframe
-    * `frequency` (str) : see [pandas doc](
+    - `date_column` (str): name of column containing the date in the dataframe
+    - `frequency` (str) : see [pandas doc](
     http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases)
-    * `date_column_format` (optional: str): format of the date in date_column
-    * `format` (optional: str): format of the date e.g. '%d/%m/%Y' (see [pandas doc](
+    - `date_column_format` (optional: str): format of the date in date_column
+    - `format` (optional: str): format of the date e.g. '%d/%m/%Y' (see [pandas doc](
         https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior))
         WARNING: only use if `granularities` is None.
-    * `granularities` (optional: dict):
-        * keys : name of the granularity
-        * values (str): Format of the granularity e.g. '%d/%m/%Y' (see [pandas doc](
+    - `granularities` (optional: dict):
+        - keys : name of the granularity
+        - values (str): Format of the granularity e.g. '%d/%m/%Y' (see [pandas doc](
             https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior))
-    * `others_format` (optional: dict) : Add new columns for each key
-        * key (str) : name of the column
-        * values (str): format of the granularity e.g. '%d/%m/%Y' (see [pandas doc](
+    - `others_format` (optional: dict) : Add new columns for each key
+        - key (str) : name of the column
+        - values (str): format of the granularity e.g. '%d/%m/%Y' (see [pandas doc](
             https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior))
-    * `times_delta` (optional: dict) : Add new columns for each key
-        * key (str) : name of the column
-        * values (str): time delta (e.g. '+1 day', '+3 day', '-4 month')
+    - `times_delta` (optional: dict) : Add new columns for each key
+        - key (str) : name of the column
+        - values (str): time delta (e.g. '+1 day', '+3 day', '-4 month')
     """
 
     start_date = pd.to_datetime(df[date_column], format=date_column_format).min()

--- a/toucan_data_sdk/utils/generic/date_requester.py
+++ b/toucan_data_sdk/utils/generic/date_requester.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 
-def date_requester_generator(start_date, end_date, frequency,
+def date_requester_generator(df, date_column, frequency, date_column_format=None,
                              format='%Y-%m-%d', granularities=None,
                              others_format=None, times_delta=None):
     """
@@ -42,6 +42,9 @@ def date_requester_generator(start_date, end_date, frequency,
         - values (str): time delta
             Examples : '+1 day' '+3 day' '-4 month'
     """
+
+    start_date = pd.to_datetime(df[date_column], format=date_column_format).min()
+    end_date = pd.to_datetime(df[date_column], format=date_column_format).max()
 
     granularities = granularities or {'date': format}
     others_format = others_format or {}

--- a/toucan_data_sdk/utils/generic/date_requester.py
+++ b/toucan_data_sdk/utils/generic/date_requester.py
@@ -5,43 +5,37 @@ def date_requester_generator(df, date_column, frequency, date_column_format=None
                              format='%Y-%m-%d', granularities=None,
                              others_format=None, times_delta=None):
     """
-    Return a DataFrame containing at least 3 columns :
-    - "DATE" : Label of date
-    - "DATETIME" : Date in datetime dtype
-    - "GRANULARITY" : Granualrity of date
+    **From a dataframe containing dates in a column, return a dataframe**
+    **with at least 3 columns :**
+    **- "DATE" : Label of date**
+    **- "DATETIME" : Date in datetime dtype**
+    **- "GRANULARITY" : Granualrity of date**
 
-    Arguments
-    #########
-
-    Mandatory :
-    -----------
-    - df (DataFrame) : dataframe from which  start and end date will be compute
-    - date_column (str): name of column containing date in df
-    - frequency (str) : http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
-
-    Optional :
-    ----------
-    - date_column_format: format of the date in date_column
-    - format: format of the date. !!! only use if granularity is None
+    - `date_column` (str): name of column containing the date in the dataframe
+    - `frequency` (str) : see [pandas doc](
+    http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases)
+    - `date_column_format` (optional: str): format of the date in date_column
+    - `format` (optional: str): format of the date. !!! only use if granularity is None.
         NB : same format in Toucan Toco
-        Example : '%d/%m/%Y'
-        https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
-    - granularities (dict):
+        _Example : '%d/%m/%Y'_ (see [pandas doc](
+        https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior))
+    - `granularities` (optional: dict):
         - keys : name of the granularity
         - values (str): Format of the granularity.
             NB : same format in Toucan Toco
-            Example : '%d/%m/%Y'
-            https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
-    - others_format (dict) : Add new columns for each key
+            _Example : '%d/%m/%Y'_ (see [pandas doc](
+            https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior))
+    - `others_format` (optional: dict) : Add new columns for each key
         - key (str) : name of the column
         - values (str): format of the granularity.
             NB : same format in Toucan Toco
-            Example : '%d/%m/%Y'
-            https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
-    - times_delta (dict) : Add new columns for each key
+            _Example : '%d/%m/%Y'_ (see [pandas doc](
+            https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior))
+
+    - `times_delta` (optional: dict) : Add new columns for each key
         - key (str) : name of the column
         - values (str): time delta
-            Examples : '+1 day' '+3 day' '-4 month'
+            _Examples : '+1 day', '+3 day', '-4 month'_
     """
 
     start_date = pd.to_datetime(df[date_column], format=date_column_format).min()


### PR DESCRIPTION
### Breaking change dans la fonction `date_requester_generator`

**Avant**: 
On renseignait "a la main" la `start_date` et la `end_date` pour generer la "date range" du date requesters.

**Maintenant** : 
La fonction prend en entrée un DataFrame et le nom d'une colonne de date : 
- la `start_date` vaut la date la plus ancienne de cette colonne
- la `end_date` vaut la date la plus récente

--> cela rend la fonction utilisable en postprocess 

-----------
NB : aucune augment ne  sera impacté par ce changement. Pour le verifier j'ai utilisé le parser les analytics Toucan : 
```
from toucan_data_sdk import ToucanDataSdk
import pandas as pd
import getpass

instance = 'analytics'
small_app = 'explore-config'
instance_url = f"https://api-{instance}.toucantoco.guru"
username = 'toucantoco'
try:
    auth = get_auth(instance)
except Exception:
    auth = (username, getpass.getpass())
    
sdk = ToucanDataSdk(instance_url, small_app=small_app, auth=auth)
datasources = sdk.get_datasources(['all_configs_input'])

all_configs = datasources['all_configs_input']

sub_df = all_configs[all_configs['type_file'] == 'augment.py']

sub_df['content'].str.contains('date_requester_generator').sum()
```