### PR TITLE
groupby :: manage multi-aggregations on 1 column

### DIFF
--- a/tests/utils/postprocess/test_groupby.py
+++ b/tests/utils/postprocess/test_groupby.py
@@ -45,3 +45,18 @@ def test_two_group_cols_two_value_cols():
          {'ENTITY': 'B', 'YEAR': '2018', 'VALUE_1': 110, 'VALUE_2': 6.5}
          ])
     assert df.sort_index(axis=1).equals(df_expected.sort_index(axis=1))
+
+
+def test_multiple_aggregation_on_one_column():
+    df = groupby(
+        df=data,
+        group_cols='ENTITY',
+        aggregations={
+            'VALUE_1': ['sum', 'count']
+        }
+    )
+    df_expected = pd.DataFrame(
+        [{'ENTITY': 'A', 'sum_VALUE_1': 70, 'count_VALUE_1': 4},
+         {'ENTITY': 'B', 'sum_VALUE_1': 210, 'count_VALUE_1': 4}
+         ])
+    assert df.sort_index(axis=1).equals(df_expected.sort_index(axis=1))

--- a/toucan_data_sdk/utils/postprocess/groupby.py
+++ b/toucan_data_sdk/utils/postprocess/groupby.py
@@ -59,8 +59,11 @@ def groupby(df, *, group_cols: Union[str, List[str]],
     if df.columns.nlevels == 2:
         level_0 = df.columns.get_level_values(0)
         level_1 = df.columns.get_level_values(1)
-        new_columns = [f'{x}_{y}' for (x, y) in zip(level_1, level_0)]
-        # Remove leading underscore for index columns
-        new_columns = [x[1:] if x[0] == "_" else x for x in new_columns]
+        new_columns = []
+        for (x, y) in zip(level_1, level_0):
+            if x == '':
+                new_columns.append(y)
+            else:
+                new_columns.append(f'{x}_{y}')
         df.columns = new_columns
     return df

--- a/toucan_data_sdk/utils/postprocess/groupby.py
+++ b/toucan_data_sdk/utils/postprocess/groupby.py
@@ -59,11 +59,7 @@ def groupby(df, *, group_cols: Union[str, List[str]],
     if df.columns.nlevels == 2:
         level_0 = df.columns.get_level_values(0)
         level_1 = df.columns.get_level_values(1)
-        new_columns = []
-        for (x, y) in zip(level_1, level_0):
-            if x == '':
-                new_columns.append(y)
-            else:
-                new_columns.append(f'{x}_{y}')
+        new_columns = [(f'{x}_{y}' if x else y) for (x, y)
+                       in zip(level_1, level_0)]
         df.columns = new_columns
     return df

--- a/toucan_data_sdk/utils/postprocess/groupby.py
+++ b/toucan_data_sdk/utils/postprocess/groupby.py
@@ -59,7 +59,7 @@ def groupby(df, *, group_cols: Union[str, List[str]],
     if df.columns.nlevels == 2:
         level_0 = df.columns.get_level_values(0)
         level_1 = df.columns.get_level_values(1)
-        new_columns = [x + "_" + y for (x, y) in zip(level_1, level_0)]
+        new_columns = [f'{x}_{y}' for (x, y) in zip(level_1, level_0)]
         # Remove leading underscore for index columns
         new_columns = [x[1:] if x[0] == "_" else x for x in new_columns]
         df.columns = new_columns


### PR DESCRIPTION
When specifying multiple aggregation functions for a same column to pandas, it creates a two-level header (with the 1st level specifying the target column name, and the second level specifying the name of the aggregation function).

This two-level header is not manageable in our app so we need to flatten it to get back to a unique level header, hence this PR.