### PR TITLE
postprocess :: rename :: fallback on default locale

### DIFF
--- a/tests/utils/postprocess/test_rename.py
+++ b/tests/utils/postprocess/test_rename.py
@@ -10,7 +10,32 @@ def test_rename():
         'columns': {'hello': {'fr': 'bonjour'}},
         'locale': 'fr'
     }
-    data_translated = [{'bonjour': 'monde'}]
     df = rename(data, **config)
     res = [{k: v for k, v in zip(df.columns, row)} for row in df.values]
-    assert res == data_translated
+    assert res == [{'bonjour': 'monde'}]
+
+
+def test_rename_unknown_locale_with_en():
+    """It should fallback on en if locale is not found"""
+    data = pd.DataFrame([{'hello': 'world'}])
+    config = {
+        'values': {'world': {'en': 'WORLD'}},
+        'columns': {'hello': {'en': 'HELLO'}},
+        'locale': 'fr'
+    }
+    df = rename(data, **config)
+    res = [{k: v for k, v in zip(df.columns, row)} for row in df.values]
+    assert res == [{'HELLO': 'WORLD'}]
+
+
+def test_rename_unknown_locale_without_en():
+    """It should fallback on untranslated if locale is not found"""
+    data = pd.DataFrame([{'hello': 'world'}])
+    config = {
+        'values': {'world': {'fr': 'monde'}},
+        'columns': {'hello': {'fr': 'bonjour'}},
+        'locale': 'it'
+    }
+    df = rename(data, **config)
+    res = [{k: v for k, v in zip(df.columns, row)} for row in df.values]
+    assert res == [{'hello': 'world'}]


### PR DESCRIPTION
Avoid crash in `rename` postprocess if asked locale is not found in
translations. It is now possible to specify a fallback locale that will
be used if specified locale is not found. If both locales can't be
found, return the untranslated strings but don't crash.