### PR TITLE
Fix :: date requester generator granularity

### DIFF
--- a/tests/utils/generic/test_date_requester.py
+++ b/tests/utils/generic/test_date_requester.py
@@ -16,6 +16,11 @@ df_2 = pd.DataFrame({
     "my_kpi": [1, 2, 3, 4, 5]
 })
 
+df_3 = pd.DataFrame({
+    "date": ['2018-03-01', '2017-10-01'],
+    "my_kpi": [1, 5]
+})
+
 
 def test_date_requester_generator():
     # mandatory only
@@ -91,6 +96,18 @@ def test_date_requester_generator():
     assert result.shape == (5, 4)
     assert "Tomorow" in result.columns
     assert list(result["Tomorow"]) == expected_tomorow
+
+    # with multi-ganularity and others_format
+    result = date_requester_generator(df_3, "date",
+                                      frequency='M',
+                                      granularities={"Mois": "%Y-%m", "Annee": "%Y"},
+                                      others_format={'DYEAR': '%Y', "DMONTH": '%m'})
+
+    assert result.shape == (7, 5)
+    assert list(result["DATE"]) == ['2017-10', '2017-11', '2017-12', '2018-01', '2018-02', '2017', '2018']
+    assert list(result["GRANULARITY"]) == ['Mois']*5+["Annee"]*2
+    assert list(result["DYEAR"]) == ['2017', '2017', '2017', '2018', '2018', '2017', '2018']
+    assert list(result["DMONTH"]) == ["10", "11", "12", "01", "02", "10", "01"]
 
 
 def test_date_requester_generator_locales():

--- a/toucan_data_sdk/utils/generic/date_requester.py
+++ b/toucan_data_sdk/utils/generic/date_requester.py
@@ -102,9 +102,9 @@ def date_requester_generator(
 
         for granularity_name, granularity_format in granularities.items():
             date_range_label = date_range.strftime(granularity_format)
-            a = list(set(date_range_label))
-            index_unique = list(set([a.index(x) for x in date_range_label]))
-            date_range_datetime = date_range[index_unique]
+            date_range_label_as_list = list(date_range_label)
+            first_index = list(set([date_range_label_as_list.index(x) for x in date_range_label]))
+            date_range_datetime = date_range[first_index]
             date_range_label = date_range_label.unique()
 
             result_df['DATE'] += list(date_range_label)


### PR DESCRIPTION
# Fix date requester generator granularity

### Description du bug

Avec cette configuration: 

```
query: 
  domain: "ABE_ABP"
postprocess: [
  {
    date_requester_generator:
      date_column: "date_doc"
      date_column_format: "%Y-%m-%d"
      frequency: "M"
      granularities:
        Mois: "%Y-%m"
        Annee: "%Y"
      others_format:
        DYEAR: "%Y"
        DMONTH: "%m"
  }
  {
    rename:
      columns:
        GRANULARITY:
          fr: "DTYPE"
          en: "DTYPE"
        DATE:
          fr: "DNAME"
          en: "DNAME"
  }
]
```

On obtient

<img width="767" alt="Capture_d’écran_2019-05-29_à_10 18 48" src="https://user-images.githubusercontent.com/15191323/58722232-3a402380-83d7-11e9-8f73-53ac808a6e52.png">

Sur les 3 lignes en rouge on veut les bonnes dates dans la colonne `DATE_TIME`

