### PR TITLE
Concat integer columns without trailing .0

### DIFF
--- a/tests/utils/postprocess/test_text.py
+++ b/tests/utils/postprocess/test_text.py
@@ -115,6 +115,20 @@ def test_concat(df):
     assert df['res'].tolist() == ['pika/77/1', 'fway/88/3', 'zbruh/99/2', 'wesh/11/1']
 
 
+def test_concat_integer_columns():
+    """It should keep the numbers as int if possible in concat"""
+    df = pd.DataFrame({'a': ['pika', 'bulbi'],
+                       'b': [1, None],
+                       'c': [1.0, 2.1],
+                       })
+    concat_df = concat(df.copy(), columns=['a', 'b'], new_column='res')
+    assert concat_df['res'].tolist() == ['pika1', 'bulbi']
+    assert concat_df[['a', 'b', 'c']].equals(df)
+
+    assert concat(df, columns=['a', 'c'], new_column='res')['res'].tolist() == ['pika1.0', 'bulbi2.1']
+    assert concat(df, columns=['b', 'c'], new_column='res')['res'].tolist() == ['11.0', '2.1']
+
+
 def test_contains(df):
     df = contains(df, 'b', new_column='res', pat='ca', case=False)
     assert df['res'].tolist() == [False, True, False, True]


### PR DESCRIPTION
Issue https://github.com/ToucanToco/toucan-data-sdk/issues/23

When concat is used on columns with NaN values, the column is considered with type `float` leading to trailing `.0` in the concatenation

With
```python
>>> df
       a    b
0   pika  1.0
1  bulbi  NaN
```

**BEFORE**
```python
>>> concat(df, columns=['a', 'b'], new_column='res')
       a    b       res
0   pika  1.0   pika1.0
1  bulbi  NaN  bulbinan
```

**AFTER**
```python
>>> concat(df, columns=['a', 'b'], new_column='res')
       a    b    res
0   pika  1.0  pika1
1  bulbi  NaN  bulbi
```

