### PR TITLE
Fix postprocess pivot when values have mixed dtypes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = toucan_data_sdk
 description = Toucan data SDK
 author = Toucan Toco
 url = https://github.com/ToucanToco/toucan-data-sdk
-version = 6.2.2
+version = 6.2.3
 license = BSD
 classifiers=
     Intended Audience :: Developers

--- a/tests/utils/postprocess/test_pivot.py
+++ b/tests/utils/postprocess/test_pivot.py
@@ -25,7 +25,7 @@ def test_pivot():
         [
             {'variable': 'toto', 'wave': 'wave1', 'year': 2014, 'value': 'value1'},
             {'variable': 'toto', 'wave': 'wave1', 'year': 2015, 'value': 'value2'},
-            {'variable': 'toto', 'wave': 'wave1', 'year': 2016, 'value': 'value3'},
+            {'variable': 'toto', 'wave': 'wave1', 'year': 2016, 'value': 3},  # mixed dtypes
             {'variable': 'toto', 'wave': 'wave1', 'year': 2016, 'value': 'value4'},
             {'variable': 'toto', 'wave': 'wave1', 'year': 2014, 'value': 'value5'},
         ]
@@ -33,7 +33,7 @@ def test_pivot():
     res = pivot(data_obj, **kwargs)
     assert res[2014][0] == 'value1 value5'
     assert res[2015][0] == 'value2'
-    assert res[2016][0] == 'value3 value4'
+    assert res[2016][0] == '3 value4'
 
 
 def test_pivot_agg_sum():

--- a/toucan_data_sdk/utils/postprocess/pivot.py
+++ b/toucan_data_sdk/utils/postprocess/pivot.py
@@ -55,6 +55,8 @@ def pivot(
     |   toto   |  wave 1 |  300   | 250  | 450  |
     """
     if df.dtypes[value].type == np.object_:
+        # Force the value column to be str-only (because mixed dtypes causes errors)
+        df[value] = df[value].astype(str)
         df = pd.pivot_table(
             df, index=index, columns=column, values=value, aggfunc=lambda x: ' '.join(x)
         )


### PR DESCRIPTION
With this dataframe (containing mixed dtypes on "score" column):
```python
>>> df
  joueur     kpi   score
0  alice  pacman      10
1  alice  pacman      20
2  alice  tetris  blabla
3  alice  tetris      40
```

We had this strange behaviour:
```python
>>> pivot(df, index=['joueur'], column='kpi', value='score')
    joueur            pacman            tetris
0    alice  joueur kpi score  joueur kpi score
```

Now we have:
```python
>>> pivot(df, index=['joueur'], column='kpi', value='score')
    joueur pacman     tetris
0    alice  10 20  blabla 40
```