### PR TITLE
Roll_up :: Add a `parent` column to the returned dataframe

### DIFF
--- a/tests/fixtures/roll_up.csv
+++ b/tests/fixtures/roll_up.csv
@@ -1,7 +1,7 @@
-Location,Type,population,value,Country,Region,City
-Montreuil,City,9,3.5,France,Idf,Montreuil
-Paris,City,200,3.3,France,Idf,Paris
-Lille,City,20,2.7,France,Nord,Lille
-Idf,Region,209,6.8,France,Idf,
-Nord,Region,20,2.7,France,Nord,
+Location,Type,population,value,Country,Region,City,Parent
+Montreuil,City,9,3.5,France,Idf,Montreuil,Idf
+Paris,City,200,3.3,France,Idf,Paris,Idf
+Lille,City,20,2.7,France,Nord,Lille,Nord
+Idf,Region,209,6.8,France,Idf,,France
+Nord,Region,20,2.7,France,Nord,,France
 France,Country,229,9.5,France,,

--- a/tests/utils/generic/test_roll.py
+++ b/tests/utils/generic/test_roll.py
@@ -19,8 +19,12 @@ def test_roll():
         groupby_vars=['value', 'population'],
         value_name='Location',
         var_name='Type',
+        parent_name='Parent',
     )
-    res_df = res_df[['Location', 'Type', 'population', 'value', 'Country', 'Region', 'City']]
+    res_df = res_df[
+        ['Location', 'Type', 'population', 'value', 'Country', 'Region', 'City', 'Parent']
+    ]
+
     expected_output = pd.read_csv(os.path.join(fixtures_base_dir, 'roll_up.csv'))
     assert res_df.equals(expected_output)
 

--- a/toucan_data_sdk/utils/generic/roll_up.py
+++ b/toucan_data_sdk/utils/generic/roll_up.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import numpy as np
 import pandas as pd
 
 
@@ -10,6 +11,7 @@ def roll_up(
     extra_groupby_cols: List[str] = None,
     var_name: str = 'type',
     value_name: str = 'value',
+    parent_name: str = 'parent',
     agg_func: str = 'sum',
     drop_levels: List[str] = None,
 ):
@@ -21,16 +23,24 @@ def roll_up(
     ### Parameters
 
     *mandatory :*
-    - `levels` (*list of str*): name of the columns composing the hierarchy (from the top to the bottom level).
-    - `groupby_vars` (*list of str*): name of the columns with value to aggregate.
-    - `extra_groupby_cols` (*list of str*) optional: other columns used to group in each level.
+    - `levels` (*list of str*): name of the columns composing the hierarchy
+      (from the top to the bottom level).
+    - `groupby_vars` (*list of str*): name of the columns with value to
+      aggregate.
+    - `extra_groupby_cols` (*list of str*) optional: other columns used to
+      group in each level.
 
     *optional :*
-    - `var_name` (*str*) : name of the result variable column. By default, `“type”`.
-    - `value_name` (*str*): name of the result value column. By default, `“value”`.
-    - `agg_func` (*str*): name of the aggregation operation. By default, `“sum”`.
-    - `drop_levels` (*list of str*): the names of the levels that you may want to discard from the output.
-
+    - `var_name` (*str*) : name of the result variable column.
+      By default, `“type”`.
+    - `value_name` (*str*): name of the result value column.
+      By default, `“value”`.
+    - `parent_name` (*str*): name of the result parent column.
+      By default, `"parent"`.
+    - `agg_func` (*str*): name of the aggregation operation.
+      By default, `“sum”`.
+    - `drop_levels` (*list of str*): the names of the levels that you may want
+      to discard from the output.
     ---
 
     ### Example
@@ -67,7 +77,7 @@ def roll_up(
     extra_groupby_cols = extra_groupby_cols or []
     drop_levels = drop_levels or []
     previous_level = None
-    for top_level in levels_cpy:
+    for (idx, top_level) in enumerate(levels_cpy):
         # Aggregation
         gb_df = getattr(
             df.groupby(groupby_cols_cpy + extra_groupby_cols)[groupby_vars], agg_func
@@ -76,6 +86,7 @@ def roll_up(
         # Melt-like columns
         gb_df[var_name] = top_level
         gb_df[value_name] = gb_df[top_level]
+        gb_df[parent_name] = gb_df[levels_cpy[idx + 1]] if idx < len(levels_cpy) - 1 else np.NaN
         dfs.append(gb_df)
         if previous_level in drop_levels:
             del dfs[-2]


### PR DESCRIPTION
Add a `parent` column to the returned dataframe, useful for the modelisation of hierarchies