### PR TITLE
feat: new `categories_from_dates` postprocess

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := all
-isort = isort -rc toucan_data_sdk tests setup.py
+isort = isort toucan_data_sdk tests setup.py
 black = black toucan_data_sdk tests setup.py
 
 .PHONY: install

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ Develop your Toucan Toco data pipeline from the confort of your favorite environ
 
 # Installation
 
-`pip install toucan_data_sdk`
+For usage: `pip install toucan_data_sdk`
+
+For dev:
+
+Install the module in editable mode: `pip install -e .`
+
+And install the test requirements: `pip install '.[test]'`
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ For usage: `pip install toucan_data_sdk`
 
 For dev:
 
-Install the module in editable mode: `pip install -e .`
-
-And install the test requirements: `pip install '.[test]'`
+Install the module in editable mode and with test requirements: `pip install -e '.[test]'`
 
 # Usage
 

--- a/tests/utils/postprocess/test_categories_from_dates.py
+++ b/tests/utils/postprocess/test_categories_from_dates.py
@@ -1,0 +1,129 @@
+from datetime import date, timedelta
+
+import pandas as pd
+import pytest
+
+from toucan_data_sdk.utils.postprocess import categories_from_dates
+
+from .test_filter_by_date import assert_frame_equal_noindex
+
+BEFORE_YESTERDAY = (date.today() - timedelta(days=2)).strftime('%Y-%m-%d')
+YESTERDAY = (date.today() - timedelta(days=1)).strftime('%Y-%m-%d')
+TODAY = date.today().strftime('%Y-%m-%d')
+TOMORROW = (date.today() + timedelta(days=1)).strftime('%Y-%m-%d')
+
+
+@pytest.fixture
+def sample_data():
+    return [
+        {'date': '2018-01-28', 'value': 0},
+        {'date': '2018-01-28', 'value': 1},
+        {'date': '2018-01-29', 'value': 2},
+        {'date': '2018-01-30', 'value': 3},
+        {'date': '2018-01-31', 'value': 4},
+        {'date': '2018-02-01', 'value': 5},
+        {'date': '2018-02-02', 'value': 6},
+        {'date': YESTERDAY, 'value': 7},
+        {'date': TODAY, 'value': 8},
+        {'date': TOMORROW, 'value': 9},
+        {'date': BEFORE_YESTERDAY, 'value': 10},
+    ]
+
+
+def test_categories_from_dates_invalid_calls(sample_data):
+    """It should forbid invalid start/stop/atdate combinations"""
+    df = pd.DataFrame(sample_data)
+    with pytest.raises(TypeError):
+        # range_steps is empty
+        categories_from_dates(df, 'date', 'my_categories', range_steps=[])
+    with pytest.raises(TypeError):
+        # category_names should have length 2
+        categories_from_dates(
+            df, 'date', 'my_categories', range_steps=['2018-01-01'], category_names=['A']
+        )
+    with pytest.raises(ValueError):
+        # bad date format
+        categories_from_dates(
+            df, 'date', 'my_categories', range_steps=['2018-01-01'], date_format='%m %Y'
+        )
+    with pytest.raises(ValueError):
+        # bad date format
+        categories_from_dates(
+            df, 'date', 'my_categories', range_steps=['01 2018'], date_format='%m %Y'
+        )
+    with pytest.raises(ValueError):
+        # bad offset syntax (missing parenthesis)
+        categories_from_dates(
+            df, 'date', 'my_categories', range_steps=['2018-01-01 + 1day'], date_format='%m %Y'
+        )
+
+
+def test_categories_from_dates(sample_data):
+    """It should create a new column 'my_categories'"""
+    df = pd.DataFrame(sample_data)
+    df = categories_from_dates(
+        df, 'date', 'my_categories', range_steps=['2018-01-31', '2018-02-03']
+    )
+    expected = df.copy()
+    expected['my_categories'] = [
+        'Category 1',
+        'Category 1',
+        'Category 1',
+        'Category 1',
+        'Category 2',
+        'Category 2',
+        'Category 2',
+        'Category 3',
+        'Category 3',
+        'Category 3',
+        'Category 3',
+    ]
+    assert_frame_equal_noindex(df, expected)
+
+
+def test_categories_from_dates_with_offset(sample_data):
+    """It should create a new column 'my_categories'"""
+    df = pd.DataFrame(sample_data)
+    expected = df.copy()
+    expected['my_categories'] = [
+        'Category 1',
+        'Category 1',
+        'Category 1',
+        'Category 1',
+        'Category 1',
+        'Category 1',
+        'Category 1',
+        'Category 2',
+        'Category 3',
+        'Category 3',
+        'Category 2',
+    ]
+    df = categories_from_dates(df, 'date', 'my_categories', range_steps=['(TODAY)-10days', 'TODAY'])
+    assert_frame_equal_noindex(df, expected)
+
+
+def test_categories_from_dates_with_category_names(sample_data):
+    """It should create a new column 'my_categories'"""
+    df = pd.DataFrame(sample_data)
+    expected = df.copy()
+    expected['my_categories'] = [
+        'Old',
+        'Old',
+        'Old',
+        'Old',
+        'Old',
+        'Old',
+        'Old',
+        'Recent',
+        'Recent',
+        'Futur',
+        'Recent',
+    ]
+    df = categories_from_dates(
+        df,
+        'date',
+        'my_categories',
+        range_steps=['(TODAY)-10days', '(TODAY)+1days'],
+        category_names=['Old', 'Recent', 'Futur'],
+    )
+    assert_frame_equal_noindex(df, expected)

--- a/tests/utils/postprocess/test_categories_from_dates.py
+++ b/tests/utils/postprocess/test_categories_from_dates.py
@@ -2,10 +2,9 @@ from datetime import date, timedelta
 
 import pandas as pd
 import pytest
+from pandas.testing import assert_frame_equal
 
 from toucan_data_sdk.utils.postprocess import categories_from_dates
-
-from .test_filter_by_date import assert_frame_equal_noindex
 
 BEFORE_YESTERDAY = (date.today() - timedelta(days=2)).strftime('%Y-%m-%d')
 YESTERDAY = (date.today() - timedelta(days=1)).strftime('%Y-%m-%d')
@@ -78,7 +77,7 @@ def test_categories_from_dates(sample_data):
         'Category 3',
         'Category 3',
     ]
-    assert_frame_equal_noindex(df, expected)
+    assert_frame_equal(df, expected)
 
 
 def test_categories_from_dates_with_offset(sample_data):
@@ -99,7 +98,7 @@ def test_categories_from_dates_with_offset(sample_data):
         'Category 2',
     ]
     df = categories_from_dates(df, 'date', 'my_categories', range_steps=['(TODAY)-10days', 'TODAY'])
-    assert_frame_equal_noindex(df, expected)
+    assert_frame_equal(df, expected)
 
 
 def test_categories_from_dates_with_category_names(sample_data):
@@ -126,4 +125,4 @@ def test_categories_from_dates_with_category_names(sample_data):
         range_steps=['(TODAY)-10days', '(TODAY)+1days'],
         category_names=['Old', 'Recent', 'Futur'],
     )
-    assert_frame_equal_noindex(df, expected)
+    assert_frame_equal(df, expected)

--- a/toucan_data_sdk/utils/postprocess/__init__.py
+++ b/toucan_data_sdk/utils/postprocess/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 from .add_aggregation_columns import add_aggregation_columns
 from .argmax import argmax, argmin
+from .categories_from_dates import categories_from_dates
 from .converter import cast, change_date_format, convert_datetime_to_str, convert_str_to_datetime
 from .cumsum import cumsum
 from .fillna import fillna

--- a/toucan_data_sdk/utils/postprocess/categories_from_dates.py
+++ b/toucan_data_sdk/utils/postprocess/categories_from_dates.py
@@ -96,9 +96,12 @@ def categories_from_dates(
     df[date_col_at_date_format] = pd.to_datetime(df[date_col], format=date_format)
     df[new_column] = ''
 
+    # first category
     df[new_column][
         df[date_col_at_date_format] < parse_date(range_steps[0], date_format)
     ] = category_names[0]
+
+    # second to before last category
     for i in range(len(range_steps[:-1])):
         start = range_steps[i]
         stop = range_steps[i + 1]
@@ -106,8 +109,10 @@ def categories_from_dates(
             df[date_col_at_date_format] >= parse_date(start, date_format)
         )
         df[new_column][mask] = category_names[i + 1]
+
+    # last category
     df[new_column][
         df[date_col_at_date_format] >= parse_date(range_steps[-1], date_format)
     ] = category_names[-1]
 
-    return df.drop(date_col_at_date_format, axis=1)
+    return df.drop(columns=date_col_at_date_format)

--- a/toucan_data_sdk/utils/postprocess/categories_from_dates.py
+++ b/toucan_data_sdk/utils/postprocess/categories_from_dates.py
@@ -15,7 +15,7 @@ def categories_from_dates(
     date_format: str = '%Y-%m-%d',
 ):
     """
-    Create a new column of categories based on a date column
+    Create a new column of categories based on a date column.
     This function will gather into categories dates from the date column
     based on range steps.
 
@@ -29,22 +29,21 @@ def categories_from_dates(
 
     *mandatory :*
     - `date_col` (*str*): name of the date column
-    - `new_column` (*str*): name of the categories column to be created
-    - `range_steps` (*list* of *str*): a list of valid date. Each date should be a string
-    matching `date_fmt` and parseable by `strptime`
-    but some offset can also be added using `(datestr) + OFFSET` or `(datestr) -
-    OFFSET` syntax. When using this syntax, `OFFSET` should be understable by
-    `pandas.Timedelta` (cf.
-    http://pandas.pydata.org/pandas-docs/stable/timedeltas.html) and `w`, `week`
-    `month` and `year` offset keywords are also accepted. `datestr` MUST be wrapped
-    with parenthesis. Additionally, the following symbolic names are supported: `TODAY`,
-    `YESTERDAY`, `TOMORROW`.
+    - `new_column` (*str*): name of the column for created categories
+    - `range_steps` (*list* of *str*): a list of valid dates.
+    Each date should be a string matching `date_fmt` and parsable by `strptime`
+    but some offset can also be added using `(datestr) + OFFSET` or `(datestr) - OFFSET` syntax.
+    When using this syntax, `OFFSET` should be understable by `pandas.Timedelta`
+    (see http://pandas.pydata.org/pandas-docs/stable/timedeltas.html)
+    and `w`, `week`, `month` and `year` offset keywords are also accepted.
+    Additionally, the following symbolic names are supported: `TODAY`, `YESTERDAY`, `TOMORROW`.
+    _NOTE_: `datestr` **MUST** be wrapped with parenthesis.
 
     *optional :*
-    - `category_names` (*list* of *str*): names of the categories to be created. This list must have a length equal to range_step **plus one**
+    - `category_names` (*list* of *str*): names of the categories to be created.
+    This list must have a length equal to `range_step` **plus one**
     - `date_format` (*str*): expected date format in column `date_col` (see [available formats](
     https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior)
-
 
     ### Example:
 

--- a/toucan_data_sdk/utils/postprocess/categories_from_dates.py
+++ b/toucan_data_sdk/utils/postprocess/categories_from_dates.py
@@ -1,0 +1,114 @@
+from typing import List, Optional
+from uuid import uuid4
+
+import pandas as pd
+
+from .filter_by_date import parse_date
+
+
+def categories_from_dates(
+    df,
+    date_col: str,
+    new_column: str,
+    range_steps: List[str],
+    category_names: Optional[List[str]] = None,
+    date_format: str = '%Y-%m-%d',
+):
+    """
+    Create a new column of categories based on a date column
+    This function will gather into categories dates from the date column
+    based on range steps.
+
+    For instance, the dates: [2018-01-02, 2018-01-06, 2018-01-15, 2018-01-16, 2018-01-20]
+    with the steps: [2018-01-07, 2018-01-18] will give 3 categories:
+    - First category: [2018-01-02, 2018-01-06]
+    - Second category: [2018-01-15, 2018-01-16]
+    - Third category: [2018-01-20]
+
+    ### Parameters
+
+    *mandatory :*
+    - `date_col` (*str*): name of the date column
+    - `new_column` (*str*): name of the categories column to be created
+    - `range_steps` (*list* of *str*): a list of valid date. Each date should be a string
+    matching `date_fmt` and parseable by `strptime`
+    but some offset can also be added using `(datestr) + OFFSET` or `(datestr) -
+    OFFSET` syntax. When using this syntax, `OFFSET` should be understable by
+    `pandas.Timedelta` (cf.
+    http://pandas.pydata.org/pandas-docs/stable/timedeltas.html) and `w`, `week`
+    `month` and `year` offset keywords are also accepted. `datestr` MUST be wrapped
+    with parenthesis. Additionally, the following symbolic names are supported: `TODAY`,
+    `YESTERDAY`, `TOMORROW`.
+
+    *optional :*
+    - `category_names` (*list* of *str*): names of the categories to be created. This list must have a length equal to range_step **plus one**
+    - `date_format` (*str*): expected date format in column `date_col` (see [available formats](
+    https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior)
+
+
+    ### Example:
+
+    **Input**
+
+    |    date      |    value   |
+    |:------------:|:----------:|
+    |  2018-01-28  |      1     |
+    |  2018-01-28  |      2     |
+    |  2018-01-29  |      3     |
+    |  2018-01-30  |      1     |
+    |  2018-02-01  |      6     |
+    |  2019-01-05  |      7     |
+    |  2019-01-06  |      7     |
+    |  2019-01-07  |      1     |
+    |  2019-01-04  |      1     |
+
+    ```cson
+    categories_from_dates:
+      date_col: 'date'
+      new_column: 'categories'
+      range_steps: ['(TODAY)-10days', '(TODAY)+1days']
+      category_names: ['Old', 'Recent', 'Futur']
+    ```
+
+    **Output**
+
+    *Assuming today is 2019-01-06*
+
+    |    date      |    value   | categories |
+    |:------------:|:----------:|:----------:|
+    |  2018-01-28  |      1     |    Old     |
+    |  2018-01-28  |      2     |    Old     |
+    |  2018-01-29  |      3     |    Old     |
+    |  2018-01-30  |      1     |    Old     |
+    |  2018-02-01  |      6     |    Old     |
+    |  2019-01-05  |      7     |   Recent   |
+    |  2019-01-06  |      7     |   Futur    |
+    |  2019-01-07  |      1     |   Futur    |
+    |  2019-01-04  |      1     |   Recent   |
+    """
+
+    category_names = category_names or [f'Category {i+1}' for i in range(len(range_steps) + 1)]
+    if len(range_steps) == 0:
+        raise TypeError('range_steps should not have length 0')
+    if len(range_steps) + 1 != len(category_names):
+        raise TypeError('category_names should have length len(range_steps)+1')
+
+    date_col_at_date_format = str(uuid4())
+    df[date_col_at_date_format] = pd.to_datetime(df[date_col], format=date_format)
+    df[new_column] = ''
+
+    df[new_column][
+        df[date_col_at_date_format] < parse_date(range_steps[0], date_format)
+    ] = category_names[0]
+    for i in range(len(range_steps[:-1])):
+        start = range_steps[i]
+        stop = range_steps[i + 1]
+        mask = (df[date_col_at_date_format] < parse_date(stop, date_format)) & (
+            df[date_col_at_date_format] >= parse_date(start, date_format)
+        )
+        df[new_column][mask] = category_names[i + 1]
+    df[new_column][
+        df[date_col_at_date_format] >= parse_date(range_steps[-1], date_format)
+    ] = category_names[-1]
+
+    return df.drop(date_col_at_date_format, axis=1)

--- a/toucan_data_sdk/utils/postprocess/math.py
+++ b/toucan_data_sdk/utils/postprocess/math.py
@@ -16,9 +16,9 @@ def _basic_math_operation(df, new_column, column_1, column_2, op):
     Will create a new column named `new_column`
     """
     if not isinstance(column_1, (str, int, float)):
-        raise TypeError(f'column_1 must be a string, an integer or a float')
+        raise TypeError('column_1 must be a string, an integer or a float')
     if not isinstance(column_2, (str, int, float)):
-        raise TypeError(f'column_2 must be a string, an integer or a float')
+        raise TypeError('column_2 must be a string, an integer or a float')
 
     if isinstance(column_1, str):
         column_1 = df[column_1]


### PR DESCRIPTION
# New postprocess  `categories_from_dates`

Create a new column of categories based on a date column
This function will gather into categories dates from the date column
based on range steps.

For instance, the dates: [2018-01-02, 2018-01-06, 2018-01-15, 2018-01-16, 2018-01-20]
with the steps: [2018-01-07, 2018-01-18] will give 3 categories:
- First category: [2018-01-02, 2018-01-06]
- Second category: [2018-01-15, 2018-01-16]
- Third category: [2018-01-20]

### Parameters

*mandatory :*
- `date_col` (*str*): name of the date column
- `new_column` (*str*): name of the categories column to be created
- `range_steps` (*list* of *str*): a list of valid date. Each date should be a string
matching `date_fmt` and parseable by `strptime`
but some offset can also be added using `(datestr) + OFFSET` or `(datestr) -
OFFSET` syntax. When using this syntax, `OFFSET` should be understable by
`pandas.Timedelta` (cf.
http://pandas.pydata.org/pandas-docs/stable/timedeltas.html) and `w`, `week`
`month` and `year` offset keywords are also accepted. `datestr` MUST be wrapped
with parenthesis. Additionally, the following symbolic names are supported: `TODAY`,
`YESTERDAY`, `TOMORROW`.

*optional :*
- `category_names` (*list* of *str*): names of the categories to be created. This list must have a length equal to range_step **plus one**
- `date_format` (*str*): expected date format in column `date_col` (see [available formats](
https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior)


### Example:

**Input**

|    date      |    value   |
|:------------:|:----------:|
|  2018-01-28  |      1     |
|  2018-01-28  |      2     |
|  2018-01-29  |      3     |
|  2018-01-30  |      1     |
|  2018-02-01  |      6     |
|  2019-01-05  |      7     |
|  2019-01-06  |      7     |
|  2019-01-07  |      1     |
|  2019-01-04  |      1     |

```cson
categories_from_dates:
    date_col: 'date'
    new_column: 'categories'
    range_steps: ['(TODAY)-10days', '(TODAY)+1days']
    category_names: ['Old', 'Recent', 'Futur']
```

**Output**

*Assuming today is 2019-01-06*

|    date      |    value   | categories |
|:------------:|:----------:|:----------:|
|  2018-01-28  |      1     |    Old     |
|  2018-01-28  |      2     |    Old     |
|  2018-01-29  |      3     |    Old     |
|  2018-01-30  |      1     |    Old     |
|  2018-02-01  |      6     |    Old     |
|  2019-01-05  |      7     |   Recent   |
|  2019-01-06  |      7     |   Futur    |
|  2019-01-07  |      1     |   Futur    |
|  2019-01-04  |      1     |   Recent   |