### PR TITLE
fix(ifelse postprocess): monotonic ≠ unique

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = toucan_data_sdk
 description = Toucan data SDK
 author = Toucan Toco
 url = https://github.com/ToucanToco/toucan-data-sdk
-version = 7.1.0
+version = 7.1.1
 license = BSD
 classifiers=
     Intended Audience :: Developers

--- a/tests/utils/postprocess/test_if_else.py
+++ b/tests/utils/postprocess/test_if_else.py
@@ -27,6 +27,7 @@ rows2 = [
     [
         pd.DataFrame(rows1 + rows2),  # test for single dataframe
         pd.concat([pd.DataFrame(rows1), pd.DataFrame(rows2)]),  # test for concatenated dataframe
+        pd.concat([pd.DataFrame(rows1, index=[0, 0]), pd.DataFrame(rows2, index=[0, 0])]),  # test with not unique df.index
     ],
 )
 def test_if_else(df):

--- a/tests/utils/postprocess/test_if_else.py
+++ b/tests/utils/postprocess/test_if_else.py
@@ -27,7 +27,9 @@ rows2 = [
     [
         pd.DataFrame(rows1 + rows2),  # test for single dataframe
         pd.concat([pd.DataFrame(rows1), pd.DataFrame(rows2)]),  # test for concatenated dataframe
-        pd.concat([pd.DataFrame(rows1, index=[0, 0]), pd.DataFrame(rows2, index=[0, 0])]),  # test with not unique df.index
+        pd.concat(
+            [pd.DataFrame(rows1, index=[0, 0]), pd.DataFrame(rows2, index=[0, 0])]
+        ),  # test with not unique df.index
     ],
 )
 def test_if_else(df):

--- a/toucan_data_sdk/utils/postprocess/if_else.py
+++ b/toucan_data_sdk/utils/postprocess/if_else.py
@@ -127,9 +127,9 @@ def if_else(df, *, if_, then_, else_=None, new_column):
     | France   |   Nice   |    3  |      4     | 3.5  |
     |  Hell    | HellCity |   -10 |      0     | -5.0 |
     """
-    # If the index is not monotonic (e.g. if the dataframe is a concatenation
+    # If the index is not unique (e.g. if the dataframe is a concatenation
     # of multiple dataframes), recompute it
-    if not df.index.is_monotonic_increasing:
+    if not df.index.is_unique:
         df.index = pd.RangeIndex(len(df.index))
 
     if_sub_df = df.query(if_)


### PR DESCRIPTION
A dataframe with an index `[0, 0, 0, 0]` **is** monotonic, but will break the dataframe splitting done in the then/else stuff.