### PR TITLE
feat(postprocess) json_to_table

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = toucan_data_sdk
 description = Toucan data SDK
 author = Toucan Toco
 url = https://github.com/ToucanToco/toucan-data-sdk
-version = 7.4.1
+version = 7.4.2
 license = BSD
 classifiers=
     Intended Audience :: Developers

--- a/tests/utils/postprocess/test_json_to_table.py
+++ b/tests/utils/postprocess/test_json_to_table.py
@@ -1,0 +1,158 @@
+import pandas as pd
+import pytest
+
+from toucan_data_sdk.utils.postprocess import json_to_table
+
+data = pd.DataFrame(
+    [
+        {
+            'name': 'blah',
+            'list_col': [{'a': 1}, {'a': 2}],
+            'adict_col': {'a': 1, 'b': {'c': 1}},
+            'bdict_list_col': {'a': [{'b': 1}, {'b': 2}]},
+        }
+    ]
+)
+
+
+def test_no_op():
+    """Should retrun input df"""
+    assert json_to_table(data, 'name').equals(data)
+
+
+def test_multiple_cols_incl_no_op():
+    """Should process relevant columns even if one is not json"""
+    assert json_to_table(data, ['name', 'adict_col']).equals(
+        pd.DataFrame(
+            [
+                {
+                    'name': 'blah',
+                    'adict_col.a': 1,
+                    'adict_col.b.c': 1,
+                    'list_col': [{'a': 1}, {'a': 2}],
+                    'adict_col': {'a': 1, 'b': {'c': 1}},
+                    'bdict_list_col': {'a': [{'b': 1}, {'b': 2}]},
+                }
+            ]
+        )
+    )
+
+
+def test_list_col():
+    """Should return a line per element of the array"""
+    assert json_to_table(data, 'list_col').equals(
+        pd.DataFrame(
+            [
+                {
+                    'list_col.a': 1,
+                    'name': 'blah',
+                    'list_col': [{'a': 1}, {'a': 2}],
+                    'adict_col': {'a': 1, 'b': {'c': 1}},
+                    'bdict_list_col': {'a': [{'b': 1}, {'b': 2}]},
+                },
+                {
+                    'list_col.a': 2,
+                    'name': 'blah',
+                    'list_col': [{'a': 1}, {'a': 2}],
+                    'adict_col': {'a': 1, 'b': {'c': 1}},
+                    'bdict_list_col': {'a': [{'b': 1}, {'b': 2}]},
+                },
+            ]
+        )
+    )
+
+
+def test_dict_col():
+    """Should return one column per key of the array"""
+    assert json_to_table(data, 'adict_col').equals(
+        pd.DataFrame(
+            [
+                {
+                    'name': 'blah',
+                    'adict_col.a': 1,
+                    'adict_col.b.c': 1,
+                    'list_col': [{'a': 1}, {'a': 2}],
+                    'adict_col': {'a': 1, 'b': {'c': 1}},
+                    'bdict_list_col': {'a': [{'b': 1}, {'b': 2}]},
+                }
+            ]
+        )
+    )
+
+
+def test_dict_list_col():
+    """Should return one column per key and one line per elements of the array"""
+    assert json_to_table(data, 'bdict_list_col').equals(
+        pd.DataFrame(
+            [
+                {
+                    'bdict_list_col.a.b': 1,
+                    'name': 'blah',
+                    'bdict_list_col.a': [{'b': 1}, {'b': 2}],
+                    'list_col': [{'a': 1}, {'a': 2}],
+                    'adict_col': {'a': 1, 'b': {'c': 1}},
+                    'bdict_list_col': {'a': [{'b': 1}, {'b': 2}]},
+                },
+                {
+                    'bdict_list_col.a.b': 2,
+                    'name': 'blah',
+                    'bdict_list_col.a': [{'b': 1}, {'b': 2}],
+                    'list_col': [{'a': 1}, {'a': 2}],
+                    'adict_col': {'a': 1, 'b': {'c': 1}},
+                    'bdict_list_col': {'a': [{'b': 1}, {'b': 2}]},
+                },
+            ]
+        )
+    )
+
+
+def test_multiple_columns():
+    """Should work with an array of columns"""
+    assert json_to_table(data, ['list_col', 'adict_col']).equals(
+        pd.DataFrame(
+            [
+                {
+                    'name': 'blah',
+                    'adict_col.a': 1,
+                    'adict_col.b.c': 1,
+                    'list_col.a': 1,
+                    'list_col': [{'a': 1}, {'a': 2}],
+                    'adict_col': {'a': 1, 'b': {'c': 1}},
+                    'bdict_list_col': {'a': [{'b': 1}, {'b': 2}]},
+                },
+                {
+                    'name': 'blah',
+                    'adict_col.a': 1,
+                    'adict_col.b.c': 1,
+                    'list_col.a': 2,
+                    'list_col': [{'a': 1}, {'a': 2}],
+                    'adict_col': {'a': 1, 'b': {'c': 1}},
+                    'bdict_list_col': {'a': [{'b': 1}, {'b': 2}]},
+                },
+            ]
+        )
+    )
+
+
+def test_sep():
+    """Should work with a custom separator"""
+    assert json_to_table(data, 'adict_col', sep='_').equals(
+        pd.DataFrame(
+            [
+                {
+                    'name': 'blah',
+                    'adict_col_a': 1,
+                    'adict_col_b_c': 1,
+                    'list_col': [{'a': 1}, {'a': 2}],
+                    'adict_col': {'a': 1, 'b': {'c': 1}},
+                    'bdict_list_col': {'a': [{'b': 1}, {'b': 2}]},
+                }
+            ]
+        )
+    )
+
+
+def test_value_error():
+    """Should raise a value error when called with no columns to merge on"""
+    with pytest.raises(ValueError):
+        json_to_table(data[['adict_col', 'list_col']], columns='adict_col')

--- a/tests/utils/postprocess/test_json_to_table.py
+++ b/tests/utils/postprocess/test_json_to_table.py
@@ -20,6 +20,11 @@ def test_no_op():
     assert json_to_table(data, 'name').equals(data)
 
 
+def test_empty_df():
+    empty_df = pd.DataFrame({'name': [], 'x': []})
+    assert json_to_table(empty_df, 'name').equals(empty_df)
+
+
 def test_multiple_cols_incl_no_op():
     """Should process relevant columns even if one is not json"""
     assert json_to_table(data, ['name', 'adict_col']).equals(

--- a/toucan_data_sdk/utils/postprocess/__init__.py
+++ b/toucan_data_sdk/utils/postprocess/__init__.py
@@ -9,6 +9,7 @@ from .filter import drop_duplicates, query
 from .filter_by_date import filter_by_date
 from .groupby import groupby
 from .if_else import if_else
+from .json_to_table import json_to_table
 from .linear_regression import predict_linear
 from .math import absolute_values, add, divide, formula, multiply, round_values, subtract
 from .melt import melt

--- a/toucan_data_sdk/utils/postprocess/json_to_table.py
+++ b/toucan_data_sdk/utils/postprocess/json_to_table.py
@@ -1,0 +1,75 @@
+import uuid
+from typing import List
+
+from pandas import DataFrame, json_normalize
+
+INTERNAL_SEP = str(uuid.uuid1())
+
+
+def json_to_table(df: DataFrame, columns: List[str], sep: str = '.') -> DataFrame:
+    """
+    Flatten JSON into a table shape. Add lines for each element of a nested array.
+    Add columns for each keys of a nested object / dict.
+
+    ### Parameters
+
+    *mandatory*
+    - `columns` (*list*) : topmost level key containing nested objects
+    *optional :*
+    - `sep` (*str*) : separator used to build nested objects path in final output column names default is `.`
+    """
+
+    if isinstance(columns, str):  # support for a single column name as a string
+        columns = [columns]
+
+    merge_on = [c for c in df.columns if type(df[c][df[c].first_valid_index()]) not in (list, dict)]
+    if merge_on == []:
+        raise ValueError(
+            'Data should have at least one column with simple data type (not list or dict)'
+        )
+
+    data = df.to_dict(orient='records')  # json_normalize takes python objects as input
+    ret_data = df.copy()
+
+    for col in columns:
+
+        serie = df[col]
+        first_valid_value = serie[serie.first_valid_index()]
+
+        if not isinstance(first_valid_value, list) and not isinstance(first_valid_value, dict):
+            continue
+
+        elif isinstance(first_valid_value, dict):  # creates new columns
+
+            df_nz = json_normalize(data=data, sep=INTERNAL_SEP)
+
+        elif isinstance(first_valid_value, list):  # creates new lines
+
+            df_nz = json_normalize(
+                data=data,
+                meta=merge_on,
+                record_path=col,
+                record_prefix=f'{col}{INTERNAL_SEP}',
+                sep=INTERNAL_SEP,
+            )
+
+        # which columns where added ?
+        new_cols = [c for c in df_nz.columns if c.startswith(f'{col}{INTERNAL_SEP}')]
+
+        # which columns still need to be processed ?
+        compound_types_cols = [
+            c for c in new_cols if type(df_nz[c][df_nz[c].first_valid_index()]) in (list, dict)
+        ]
+
+        ret_data = (
+            df_nz[[c for c in df_nz.columns if c in merge_on or c in new_cols]]
+            .rename(columns={c: c.replace(INTERNAL_SEP, sep) for c in df_nz.columns})
+            .merge(ret_data)
+        )
+
+        if compound_types_cols != []:
+            ret_data = json_to_table(
+                df=ret_data, columns=[c.replace(INTERNAL_SEP, sep) for c in compound_types_cols]
+            )
+
+    return ret_data


### PR DESCRIPTION
Flatten nested JSON into a table shape. Using the following formula :

- Add lines for each element of a nested array.
- Add columns for each keys of a nested object / dict.
- Keep everything

Before we had to create complex `jq` filters for nested JSON data structures, the idea of this postprocess step is to avoid this. We will discuss with Vincent to see if/how we can integrate this into the VQB.

Implementation is probably naïve given a large enough dataset, but I want to see it used before trying to optimise it.

![Kapture 2021-02-23 at 01 52 41](https://user-images.githubusercontent.com/5766816/108789441-8c958080-757a-11eb-8b0e-1d873481023c.gif)
