### PR TITLE
feat: Support python 311

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: install poetry
         run: |
           python -m pip install -U pip
@@ -30,6 +30,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: install poetry
         run: |
           pip install -U pip

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,32 +2,46 @@
 
 [[package]]
 name = "black"
-version = "22.12.0"
+version = "23.3.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
-    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
-    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
-    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
-    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
-    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
-    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
-    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
-    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
-    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
-    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
-    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
+    {file = "black-23.3.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:0945e13506be58bf7db93ee5853243eb368ace1c08a24c65ce108986eac65915"},
+    {file = "black-23.3.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:67de8d0c209eb5b330cce2469503de11bca4085880d62f1628bd9972cc3366b9"},
+    {file = "black-23.3.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:7c3eb7cea23904399866c55826b31c1f55bbcd3890ce22ff70466b907b6775c2"},
+    {file = "black-23.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32daa9783106c28815d05b724238e30718f34155653d4d6e125dc7daec8e260c"},
+    {file = "black-23.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:35d1381d7a22cc5b2be2f72c7dfdae4072a3336060635718cc7e1ede24221d6c"},
+    {file = "black-23.3.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:a8a968125d0a6a404842fa1bf0b349a568634f856aa08ffaff40ae0dfa52e7c6"},
+    {file = "black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b"},
+    {file = "black-23.3.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:a6f6886c9869d4daae2d1715ce34a19bbc4b95006d20ed785ca00fa03cba312d"},
+    {file = "black-23.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f3c333ea1dd6771b2d3777482429864f8e258899f6ff05826c3a4fcc5ce3f70"},
+    {file = "black-23.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:11c410f71b876f961d1de77b9699ad19f939094c3a677323f43d7a29855fe326"},
+    {file = "black-23.3.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:1d06691f1eb8de91cd1b322f21e3bfc9efe0c7ca1f0e1eb1db44ea367dff656b"},
+    {file = "black-23.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50cb33cac881766a5cd9913e10ff75b1e8eb71babf4c7104f2e9c52da1fb7de2"},
+    {file = "black-23.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e114420bf26b90d4b9daa597351337762b63039752bdf72bf361364c1aa05925"},
+    {file = "black-23.3.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:48f9d345675bb7fbc3dd85821b12487e1b9a75242028adad0333ce36ed2a6d27"},
+    {file = "black-23.3.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:714290490c18fb0126baa0fca0a54ee795f7502b44177e1ce7624ba1c00f2331"},
+    {file = "black-23.3.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:064101748afa12ad2291c2b91c960be28b817c0c7eaa35bec09cc63aa56493c5"},
+    {file = "black-23.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:562bd3a70495facf56814293149e51aa1be9931567474993c7942ff7d3533961"},
+    {file = "black-23.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:e198cf27888ad6f4ff331ca1c48ffc038848ea9f031a3b40ba36aced7e22f2c8"},
+    {file = "black-23.3.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:3238f2aacf827d18d26db07524e44741233ae09a584273aa059066d644ca7b30"},
+    {file = "black-23.3.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"},
+    {file = "black-23.3.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:92c543f6854c28a3c7f39f4d9b7694f9a6eb9d3c5e2ece488c327b6e7ea9b266"},
+    {file = "black-23.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a150542a204124ed00683f0db1f5cf1c2aaaa9cc3495b7a3b5976fb136090ab"},
+    {file = "black-23.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:6b39abdfb402002b8a7d030ccc85cf5afff64ee90fa4c5aebc531e3ad0175ddb"},
+    {file = "black-23.3.0-py3-none-any.whl", hash = "sha256:ec751418022185b0c1bb7d7736e6933d40bbb14c14a0abcf9123d1b159f98dd4"},
+    {file = "black-23.3.0.tar.gz", hash = "sha256:1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940"},
 ]
 
 [package.dependencies]
 click = ">=8.0.0"
 mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
@@ -1012,4 +1026,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "607631521c938931fb5272f63529f7b16148c2d180804f79e66c1f3287be218a"
+content-hash = "8a1979a9656557d8b184dc85b62110e983f5808cc00445f722624941f1c4ad99"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ tabulate = "^0.8.9"
 toucan-client = "^1.1.0"
 
 [tool.poetry.dev-dependencies]
-black = "^22.1.0"
+black = "^23.3.0"
 flake8 = "^4.0.1"
 isort = "^5.10.1"
 mypy = "^1.2.0"

--- a/tests/utils/postprocess/test_if_else.py
+++ b/tests/utils/postprocess/test_if_else.py
@@ -1,20 +1,7 @@
-import inspect
-
 import pandas as pd
 import pytest
 
 from toucan_data_sdk.utils.postprocess import if_else
-
-
-def test_if_else_signature():
-    assert if_else.__doc__.strip().startswith("The usual if...then...else... statement")
-    assert str(inspect.signature(if_else)) == (
-        "(df: pandas.core.frame.DataFrame, *, if: str, "
-        "then: Union[str, int, float, Dict[str, Any], List[Dict[str, Any]]], "
-        "else: Union[NoneType, str, int, float, Dict[str, Any], List[Dict[str, Any]]] = None, "
-        "new_column: str) -> pandas.core.frame.DataFrame"
-    )
-
 
 rows1 = [
     {"country": "France", "city": "Paris", "clean": -1, "the rating": 3},

--- a/tests/utils/postprocess/test_if_else.py
+++ b/tests/utils/postprocess/test_if_else.py
@@ -72,3 +72,13 @@ def test_if_else(df):
     config = {"if": 'country == "France"', "then": "F", "new_column": "new"}
     res = if_else(df, **config)
     assert res["new"].tolist() == ["F", None, "F", None]
+
+
+def test_if_else_missing_args() -> None:
+    df = pd.DataFrame(rows1)
+
+    with pytest.raises(ValueError, match="if"):
+        if_else(df, new_column="coucou")
+
+    with pytest.raises(ValueError, match="then"):
+        if_else(df, new_column="coucou", **{"if": "a"})

--- a/toucan_data_sdk/utils/generic/roll_up.py
+++ b/toucan_data_sdk/utils/generic/roll_up.py
@@ -77,7 +77,7 @@ def roll_up(
     extra_groupby_cols = extra_groupby_cols or []
     drop_levels = drop_levels or []
     previous_level = None
-    for (idx, top_level) in enumerate(levels_cpy):
+    for idx, top_level in enumerate(levels_cpy):
         # Aggregation
         gb_df = getattr(
             df.groupby(groupby_cols_cpy + extra_groupby_cols)[groupby_vars], agg_func

--- a/toucan_data_sdk/utils/postprocess/if_else.py
+++ b/toucan_data_sdk/utils/postprocess/if_else.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict, List, TypeAlias, Union
+from typing import Any, Dict, List, Union
 
 import pandas as pd
+from typing_extensions import TypeAlias
 
 Condition = Dict[str, Any]
 
@@ -48,7 +49,9 @@ _Then: TypeAlias = Union[str, int, float, Condition, List[Condition]]
 _Else: TypeAlias = Union[None, str, int, float, Condition, List[Condition]]
 
 
-def if_else(df: pd.DataFrame, *, new_column: str, **kwargs: _If | _Then | _Else) -> pd.DataFrame:
+def if_else(
+    df: pd.DataFrame, *, new_column: str, **kwargs: Union[_If, _Then, _Else]
+) -> pd.DataFrame:
     """
     The usual if...then...else... statement
 

--- a/toucan_data_sdk/utils/postprocess/json_to_table.py
+++ b/toucan_data_sdk/utils/postprocess/json_to_table.py
@@ -38,7 +38,6 @@ def json_to_table(df: DataFrame, columns: Union[str, List[str]], sep: str = ".")
     ret_data = df.copy()
 
     for col in columns:
-
         serie = df[col]
         first_valid_value = _first_valid_value(serie)
 


### PR DESCRIPTION
Work items:
* Add py311 jobs
* refactor(postprocess): Do not use inspect for parameter names
   In python 3.11, the inspect module raises an Exception when an invalid parameter name is used